### PR TITLE
[박물관] 미술품 가품 구분 방법 데이터 추가

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -189,6 +189,7 @@ Find the villagers you have visited and tap the home icon on the villager's page
 "Original" = "Original";
 "Fake" = "Fake";
 "keyword" = "keyword";
+"differences" = "Differences";
 
 "Disguised on shoreline" = "Disguised on shoreline";
 "Disguised under trees" = "Disguised under trees";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -191,6 +191,7 @@
 "Whether fake" = "가짜 여부";
 "Original" = "진품";
 "Fake" = "가품";
+"differences" = "구분 방법";
 
 // MARK: - WhereHow
 "Disguised on shoreline" = "해안선 근처";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/Items/Item.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/Items/Item.swift
@@ -32,6 +32,7 @@ struct Item {
 
     var highResTexture: String?
     var genuine: Bool?
+    var fakeDifferences: Translations?
     var artCategory: ArtCategory?
     var size: Size?
     var source: String?

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Response/Museum/ArtResponseDTO.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Response/Museum/ArtResponseDTO.swift
@@ -30,6 +30,15 @@ struct ArtResponseDTO: Codable {
     let translations: Translations
     let colors: [Color]
     let concepts: [Concept]
+    let fakeDifferences: Translations?
+    
+    enum CodingKeys: String, CodingKey {
+        case name, image, highResTexture, genuine, category, buy, sell, size,
+             realArtworkTitle, artist, description, source, hhaBasePoints,
+             interact, tag, unlocked, filename, internalId, uniqueEntryId,
+             translations, colors, concepts
+        case fakeDifferences = "fake_differences"
+    }
 }
 
 enum ArtCategory: String, Codable {
@@ -147,6 +156,7 @@ extension ArtResponseDTO: DomainConvertible {
             image: self.image,
             highResTexture: self.highResTexture,
             genuine: self.genuine,
+            fakeDifferences: self.fakeDifferences,
             artCategory: self.category,
             buy: self.buy,
             sell: self.sell ?? 0,
@@ -168,6 +178,7 @@ extension Item {
         image: String,
         highResTexture: String?,
         genuine: Bool,
+        fakeDifferences: Translations?,
         artCategory: ArtCategory,
         buy: Int,
         sell: Int,
@@ -183,6 +194,7 @@ extension Item {
         self.image = image
         self.highResTexture = highResTexture
         self.genuine = genuine
+        self.fakeDifferences = fakeDifferences
         self.artCategory = artCategory
         self.buy = buy
         self.sell = sell

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/ItemOtherInfoView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/ItemOtherInfoView.swift
@@ -121,5 +121,11 @@ class ItemOtherInfoView: UIView {
         let fakeInfoLabel = descriptionLabel(genuine ? "Original".localized : "Fake".localized)
         let fakeInfo = InfoContentView(title: "Whether fake".localized, contentView: fakeInfoLabel)
         backgroundStackView.addArrangedSubviews(fakeInfo)
+        
+        if let fakeDifferences = item.fakeDifferences {
+            let fakeDetailLabel = descriptionLabel(fakeDifferences.localizedName())
+            let fakeDetail = InfoContentView(title: "differences".localized, contentView: fakeDetailLabel)
+            backgroundStackView.addArrangedSubviews(fakeDetail)
+        }
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
@@ -133,7 +133,7 @@ final class Items {
         fetchItem(FloorsRequest(), itemKey: .floors, group: group) {
             itemList.merge($0) { _, new in new }
         }
-        fetchItem(RugsRequest(), itemKey: .floors, group: group) {
+        fetchItem(RugsRequest(), itemKey: .rugs, group: group) {
             itemList.merge($0) { _, new in new }
         }
         fetchItem(OtherRequest(), itemKey: .other, group: group) {


### PR DESCRIPTION
### 📕 Issue

fix #66
feat [54cd5e7a3304eb61734d7db2087b2edd38a33022](https://github.com/leeari95/animal-crossing/commit/54cd5e7a3304eb61734d7db2087b2edd38a33022)


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] ArtResponseDTO 내에 fakeDifferences를 추가
- [x] 'floors'를 중복으로 두번 가져오는 문제 개선

### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
