### PR TITLE
[홈/대시보드] 대시보드에 랜덤하게 방문할 수 있는 NPC와 고정적으로 방문하는 NPC를 보여주도록 추가

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 "Today's Tasks" = "Today's Tasks";
 "My Villagers" = "My Villagers";
 "Collection Progress" = "Collection Progress";
+"Residents who can visit randomly on weekdays" = "Residents who can visit randomly on weekdays";
+"Residents who visit regularly" = "Residents who visit regularly";
 
 // MARK: - UserInfoView
 "Please set a name." = "Please set a name.";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 "Today's Tasks" = "오늘의 할일";
 "My Villagers" = "마을 주민";
 "Collection Progress" = "수집 현황";
+"Residents who can visit randomly on weekdays" = "평일에 랜덤하게 방문할 수 있는 주민";
+"Residents who visit regularly" = "고정으로 방문하는 주민";
 
 // MARK: - UserInfoView
 "Please set a name." = "이름을 설정해주세요.";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/NPC.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/NPC.swift
@@ -17,4 +17,16 @@ struct NPC {
     let birthday: String
     let appearanceLocation: [AppearanceLocation]?
     let translations: Translations
+    
+    var isRandomVisit: Bool {
+        ["C.J.", "Flick", "Redd", "Gulliver", "Gullivarrr", "Label", "Wisp", "Celeste"].contains(name)
+    }
+    
+    var isFixedVisit: Bool {
+        ["Saharah", "Kicks", "Leif", "Pascal", "Sable", "K.K.", "Daisy Mae"].contains(name)
+    }
+}
+
+extension NPC: Identifiable {
+    public var id: String { UUID().uuidString }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
@@ -17,6 +17,7 @@ final class DashboardCoordinator: Coordinator {
         case customTask(task: DailyTask)
         case iconChooser
         case villagerDetail(villager: Villager)
+        case npcDetail(npc: NPC)
         case progress
         case item(category: Category)
         case itemDetail(item: Item)
@@ -43,7 +44,9 @@ final class DashboardCoordinator: Coordinator {
             userInfoVM: UserInfoReactor(coordinator: self),
             tasksVM: TodaysTasksSectionReactor(coordinator: self),
             villagersVM: VillagersSectionReactor(coordinator: self),
-            progressVM: CollectionProgressSectionReactor(coordinator: self)
+            progressVM: CollectionProgressSectionReactor(coordinator: self),
+            fixeVisitdNPCListVM: NpcsSectionReactor(state: .init(), mode: .fixedVisit, coordinator: self),
+            randomVisitNPCListVM: NpcsSectionReactor(state: .init(), mode: .randomVisit, coordinator: self)
         )
         rootViewController.addChild(viewController)
     }
@@ -58,16 +61,19 @@ final class DashboardCoordinator: Coordinator {
             )
             let navigationController = UINavigationController(rootViewController: viewController)
             rootViewController.present(navigationController, animated: true)
+
         case .about:
             let viewController = AboutViewController()
             viewController.bind(to: AboutReactor(coordinator: self))
             let navigationController = UINavigationController(rootViewController: viewController)
             rootViewController.present(navigationController, animated: true)
+
         case .taskEdit:
             let viewController = TaskEditViewController()
             viewController.bind(to: TasksEditReactor(coordinator: self))
             let navigationController = UINavigationController(rootViewController: viewController)
             rootViewController.present(navigationController, animated: true)
+
         case .customTask(let task):
             let viewController = CustomTaskViewController()
             delegate = viewController
@@ -80,11 +86,13 @@ final class DashboardCoordinator: Coordinator {
             }
             let navigationController = rootViewController.visibleViewController?.navigationController as? UINavigationController
             navigationController?.pushViewController(viewController, animated: true)
+
         case .iconChooser:
             let viewController = IconChooserViewController()
             viewController.coordinator = self
             let navigationController = UINavigationController(rootViewController: viewController)
             rootViewController.visibleViewController?.present(navigationController, animated: true)
+
         case .villagerDetail(let villager):
             let viewController = VillagerDetailViewController()
             viewController.bind(
@@ -93,10 +101,21 @@ final class DashboardCoordinator: Coordinator {
             let navigationController = UINavigationController(rootViewController: viewController)
             rootViewController.present(navigationController, animated: true)
             HapticManager.shared.notification(type: .success)
+
+        case let .npcDetail(npc):
+            let viewController = NPCDetailViewController()
+            viewController.bind(
+                to: NPCDetailReactor(npc: npc, state: .init(npc: npc))
+            )
+            let navigationController = UINavigationController(rootViewController: viewController)
+            rootViewController.present(navigationController, animated: true)
+            HapticManager.shared.notification(type: .success)
+
         case .progress:
             let viewController = CollectionProgressViewController()
             viewController.bind(to: CollectionProgressReactor(coordinator: self))
             rootViewController.pushViewController(viewController, animated: true)
+
         case .item(let category):
             let viewController = ItemsViewController()
             let currentMonth = (Calendar.current.dateComponents([.month], from: Date()).month ?? 1).description
@@ -105,16 +124,20 @@ final class DashboardCoordinator: Coordinator {
                 keyword: [.month: currentMonth]
             )
             rootViewController.pushViewController(viewController, animated: true)
+
         case .itemDetail(let item):
             let viewController = ItemDetailViewController()
             viewController.bind(to: ItemDetailReactor(item: item, coordinator: self))
             rootViewController.pushViewController(viewController, animated: true)
+
         case .keyword(let title, let keyword):
             let viewController = ItemsViewController()
             viewController.bind(to: ItemsReactor(coordinator: self, mode: .keyword(title: title, category: keyword)))
             rootViewController.pushViewController(viewController, animated: true)
+
         case .pop:
             rootViewController.visibleViewController?.navigationController?.popViewController(animated: true)
+
         case .dismiss:
             rootViewController.visibleViewController?.navigationController?.dismiss(animated: true)
         }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import RxSwift
+import SwiftUI
 
 final class DashboardViewController: UIViewController {
 
@@ -60,7 +61,9 @@ final class DashboardViewController: UIViewController {
         userInfoVM: UserInfoReactor,
         tasksVM: TodaysTasksSectionReactor,
         villagersVM: VillagersSectionReactor,
-        progressVM: CollectionProgressSectionReactor
+        progressVM: CollectionProgressSectionReactor,
+        fixeVisitdNPCListVM: NpcsSectionReactor,
+        randomVisitNPCListVM: NpcsSectionReactor
     ) {
         let userInfoSection = SectionView(
             title: "My Island".localized,
@@ -82,7 +85,22 @@ final class DashboardViewController: UIViewController {
             iconName: "chart.pie.fill",
             contentView: CollectionProgressView(viewModel: progressVM)
         )
-        sectionsScrollView.addSection(userInfoSection, tasksSection, villagersSection, progressSection)
+        let randomVisitResidentsSectionView = SectionView(
+            title: "Residents who can visit randomly on weekdays".localized,
+            iconName: "bubbles.and.sparkles.fill",
+            contentView: NpcsView(randomVisitNPCListVM)
+        )
+        let fixedVisitResidentsSectionView = SectionView(
+            title: "Residents who visit regularly".localized,
+            iconName: "pin.fill",
+            contentView: NpcsView(fixeVisitdNPCListVM)
+        )
+        sectionsScrollView.addSection(userInfoSection,
+                                      tasksSection, 
+                                      villagersSection, 
+                                      progressSection, 
+                                      randomVisitResidentsSectionView, 
+                                      fixedVisitResidentsSectionView)
     }
 
     func bind(to reactor: DashboardReactor) {

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/NpcsSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/NpcsSectionReactor.swift
@@ -1,0 +1,81 @@
+//
+//  NpcsSectionReactor.swift
+//  ACNH-wiki
+//
+//  Created by Ari on 12/6/24.
+//
+
+import Foundation
+import ReactorKit
+import RxSwift
+import RxCocoa
+
+final class NpcsSectionReactor: Reactor, ObservableObject {
+    enum Action {
+        case fetch
+        case npcLongPress(index: Int)
+    }
+
+    enum Mutation {
+        case transition(route: DashboardCoordinator.Route)
+        case setNpc(_ npcs: [NPC])
+    }
+
+    struct State {
+        var npcs: [NPC] = []
+    }
+
+    @Published var initialState: State
+    private var coordinator: DashboardCoordinator?
+    private let mode: Mode
+
+    init(state: State, mode: Mode, coordinator: DashboardCoordinator?) {
+        self.initialState = state
+        self.mode = mode
+        self.coordinator = coordinator
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .fetch:
+            return mode.npcs
+                .map { Mutation.setNpc($0) }
+                .asObservable()
+            
+        case .npcLongPress(let index):
+            guard let npc = currentState.npcs[safe: index] else {
+                return Observable.empty()
+            }
+            return Observable.just(Mutation.transition(route: .npcDetail(npc: npc)))
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .transition(route):
+            coordinator?.transition(for: route)
+
+        case let .setNpc(npcs):
+            newState.npcs = npcs
+            objectWillChange.send()
+        }
+        return newState
+    }
+}
+
+extension NpcsSectionReactor {
+    enum Mode {
+        case fixedVisit
+        case randomVisit
+        
+        var npcs: Driver<[NPC]> {
+            switch self {
+            case .fixedVisit:
+                return Items.shared.fixedVisitNpcs
+            case .randomVisit:
+                return Items.shared.randomVisitNpcs
+            }
+        }
+    }
+}

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/VillagersSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/VillagersSectionReactor.swift
@@ -13,15 +13,20 @@ final class VillagersSectionReactor: Reactor {
     enum Action {
         case fetch
         case villagerLongPress(indexPath: IndexPath)
+        case villagersChecked(checked: Villager)
+        case resetCheckedVillagers
     }
 
     enum Mutation {
         case transition(route: DashboardCoordinator.Route)
         case setVillagers(_ villagers: [Villager])
+        case setCheckedVillager(_ villagers: Villager)
+        case resetCheckedVillagers
     }
 
     struct State {
         var villagers: [Villager] = []
+        var checkedVillagers: [Villager] = []
     }
 
     let initialState: State = State()
@@ -43,6 +48,12 @@ final class VillagersSectionReactor: Reactor {
                 return Observable.empty()
             }
             return Observable.just(Mutation.transition(route: .villagerDetail(villager: villager)))
+            
+        case let .villagersChecked(checkedVillager):
+            return Observable.just(Mutation.setCheckedVillager(checkedVillager))
+            
+        case .resetCheckedVillagers:
+            return Observable.just(Mutation.resetCheckedVillagers)
         }
     }
 
@@ -53,6 +64,14 @@ final class VillagersSectionReactor: Reactor {
             coordinator?.transition(for: route)
         case .setVillagers(let villagers):
             newState.villagers = villagers
+        case let .setCheckedVillager(villager):
+            if let index = newState.checkedVillagers.firstIndex(where: { $0.name == villager.name }) {
+                newState.checkedVillagers.remove(at: index)
+            } else {
+                newState.checkedVillagers.append(villager)
+            }
+        case .resetCheckedVillagers:
+            newState.checkedVillagers = []
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/NpcsView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/NpcsView.swift
@@ -1,0 +1,172 @@
+//
+//  NpcsView.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Ari on 2024/12/06.
+//
+
+import UIKit
+import RxSwift
+
+final class NpcsView: UIView {
+
+    private let disposeBag = DisposeBag()
+
+    private var heightConstraint: NSLayoutConstraint!
+    private let longPressGesture: UILongPressGestureRecognizer = {
+        let gesture = UILongPressGestureRecognizer()
+        gesture.minimumPressDuration = 0.5
+        return gesture
+    }()
+
+    private lazy var backgroundStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        stackView.spacing = 12
+        return stackView
+    }()
+
+    private lazy var collectionView: UICollectionView = {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.itemSize = CGSize(width: 50, height: 50)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.registerNib(IconCell.self)
+        collectionView.addGestureRecognizer(longPressGesture)
+        return collectionView
+    }()
+
+    private lazy var resetButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Reset".localized, for: .normal)
+        button.setTitleColor(.acText, for: .normal)
+        button.titleLabel?.font = .preferredFont(for: .footnote, weight: .semibold)
+        button.backgroundColor = .acText.withAlphaComponent(0.2)
+        button.layer.cornerRadius = 12
+        button.widthAnchor.constraint(equalToConstant: 56).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 28).isActive = true
+        return button
+    }()
+
+    private lazy var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .acText
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var emptyLabel: UILabel = {
+        let text = "vilagerEmpty".localized
+        let label = UILabel(text: text, font: .preferredFont(forTextStyle: .footnote), color: .acText)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        addSubviews(label)
+        label.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        label.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        label.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        label.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        return label
+    }()
+
+    private func updateCollectionViewHeight() {
+        let contentHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
+        heightConstraint.constant = contentHeight == .zero ? 60 : contentHeight
+    }
+
+    private func configure() {
+        addSubviews(backgroundStackView)
+        backgroundStackView.addArrangedSubviews(collectionView, descriptionLabel, resetButton)
+
+        heightConstraint = collectionView.heightAnchor.constraint(equalToConstant: 60)
+        heightConstraint.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            backgroundStackView.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            backgroundStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            collectionView.widthAnchor.constraint(equalTo: backgroundStackView.widthAnchor),
+            heightConstraint
+        ])
+    }
+
+    private func bind(to reactor: NpcsSectionReactor) {
+        Observable.just(NpcsSectionReactor.Action.fetch)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        longPressGesture.rx.event
+            .map { (longPressGesture: UIGestureRecognizer) -> IndexPath? in
+                guard let collectionView = longPressGesture.view as? UICollectionView else {
+                    return nil
+                }
+                if longPressGesture.state == .began,
+                   let indexPath = collectionView.indexPathForItem(
+                    at: longPressGesture.location(in: collectionView)
+                   ) {
+                    return indexPath
+                }
+                return nil
+            }.compactMap { $0 }
+            .map { NpcsSectionReactor.Action.npcLongPress(index: $0.item)}
+            .subscribe(onNext: { action in
+                reactor.action.onNext(action)
+            }).disposed(by: disposeBag)
+
+        reactor.state
+            .map { $0.npcs }
+            .filter { $0.isEmpty == false }
+            .take(1)
+            .bind(
+                to: collectionView.rx.items(
+                    cellIdentifier: IconCell.className,
+                    cellType: IconCell.self
+                )
+            ) { _, npc, cell in
+                cell.setImage(url: npc.iconImage)
+            }.disposed(by: disposeBag)
+
+        reactor.state
+            .map { $0.npcs }
+            .observe(on: MainScheduler.asyncInstance)
+            .subscribe(onNext: { [weak self] npcs in
+                if npcs.isEmpty {
+                    self?.emptyLabel.isHidden = false
+                    self?.backgroundStackView.isHidden = true
+                } else {
+                    self?.emptyLabel.isHidden = true
+                    self?.backgroundStackView.isHidden = false
+                    self?.descriptionLabel.text = "tip".localized
+                }
+                self?.updateCollectionViewHeight()
+                self?.layoutIfNeeded()
+            }).disposed(by: disposeBag)
+
+        collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                HapticManager.shared.selection()
+                let cell = self?.collectionView.cellForItem(at: indexPath) as? IconCell
+                cell?.checkMark()
+            }).disposed(by: disposeBag)
+
+        resetButton.rx.tap
+            .subscribe(onNext: { [weak self] _ in
+                let cells = self?.collectionView.visibleCells as? [IconCell]
+                cells?.forEach { $0.removeCheckMark() }
+            }).disposed(by: disposeBag)
+    }
+}
+
+extension NpcsView {
+    convenience init(_ viewModel: NpcsSectionReactor) {
+        self.init(frame: .zero)
+        configure()
+        bind(to: viewModel)
+    }
+}

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/VillagersView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/VillagersView.swift
@@ -128,6 +128,9 @@ final class VillagersView: UIView {
                 )
             ) { _, villager, cell in
                 cell.setImage(url: villager.iconImage)
+                if reactor.currentState.checkedVillagers.contains(where: {  $0.name == villager.name }) {
+                    cell.checkMark()
+                }
             }.disposed(by: disposeBag)
 
         reactor.state
@@ -151,12 +154,16 @@ final class VillagersView: UIView {
                 HapticManager.shared.selection()
                 let cell = self?.collectionView.cellForItem(at: indexPath) as? IconCell
                 cell?.checkMark()
+                if let villager = reactor.currentState.villagers[safe: indexPath.item] {
+                    reactor.action.onNext(.villagersChecked(checked: villager))
+                }
             }).disposed(by: disposeBag)
 
         resetButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 let cells = self?.collectionView.visibleCells as? [IconCell]
                 cells?.forEach { $0.removeCheckMark() }
+                reactor.action.onNext(.resetCheckedVillagers)
             }).disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
### 📕 Issue

fix #64 #81 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 대시보드에 랜덤하게 방문할 수 있는 NPC와 고정적으로 방문하는 NPC를 보여주도록 추가
- [x] 마을 주민을 길게 누르면 체크해두었던 데이터가 사라지는 문제 개선


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
