### PR TITLE
fix: APIRequest URL 구성 오류 수정

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Protocol/APIRequest.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Protocol/APIRequest.swift
@@ -32,7 +32,10 @@ extension APIRequest {
         if urlQuries.isEmpty == false {
             urlComponents?.percentEncodedQueryItems = urlQuries
         }
-        return url
+        guard let finalURL = urlComponents?.url else {
+            throw APIError.invalidURL(url.absoluteString)
+        }
+        return finalURL
     }
 
     func asURLRequest() throws -> URLRequest {


### PR DESCRIPTION
## Summary
- APIRequest.swift에서 쿼리 파라미터가 포함된 URL을 올바르게 반환하도록 수정
- urlComponents?.url을 사용하여 완전한 URL 반환하도록 변경

## Test plan
- [ ] API 호출 시 쿼리 파라미터가 올바르게 전송되는지 확인
- [ ] 기존 API 요청들이 정상적으로 작동하는지 테스트
- [ ] 네트워크 로그에서 올바른 URL이 구성되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)