### PR TITLE
fix: 배열 인덱스 범위 초과 및 오타 수정

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/DailyTask.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/DailyTask.swift
@@ -16,6 +16,7 @@ struct DailyTask {
     let createdDate: Date
 
     mutating func toggleCompleted(_ index: Int) {
+        guard index >= 0 && index < progressList.count else { return }
         self.progressList[index].toggle()
     }
 
@@ -107,7 +108,7 @@ extension DailyTask {
                 createdDate: Date(timeIntervalSince1970: 1654614000.0)
             ),
             DailyTask(
-                name: "Find peral",
+                name: "Find pearl",
                 icon: "Inv199",
                 isCompleted: false,
                 amount: 1,


### PR DESCRIPTION
## Summary
- DailyTask.toggleCompleted 메서드에 인덱스 범위 검증 추가
- 유효하지 않은 인덱스 전달 시 앱 크래시 방지
- "Find peral" → "Find pearl" 오타 수정

## Test plan
- [ ] 유효하지 않은 인덱스로 toggleCompleted 호출 시 크래시가 발생하지 않는지 확인
- [ ] 정상적인 인덱스로 호출 시 올바르게 동작하는지 테스트
- [ ] UI에서 올바른 텍스트 "Find pearl"이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)