### PR TITLE
fix: 자식 뷰 컨트롤러 관리 및 메모리 누수 수정

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/AppCoordinator.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/AppCoordinator.swift
@@ -63,6 +63,7 @@ extension AppCoordinator {
         }
         let viewController = PlayerViewController()
         playerViewController = viewController
+        rootViewController.addChild(viewController)
         rootViewController.view.addSubviews(viewController.view)
         rootViewController.view.bringSubviewToFront(rootViewController.tabBar)
         viewController.didMove(toParent: rootViewController)
@@ -105,7 +106,10 @@ extension AppCoordinator {
     }
 
     func removePlayerViewController() {
-        playerViewController?.view.isHidden = true
+        playerViewController?.willMove(toParent: nil)
+        playerViewController?.view.removeFromSuperview()
+        playerViewController?.removeFromParent()
+        playerViewController = nil
         MusicPlayerManager.shared.close()
     }
 }


### PR DESCRIPTION
## Summary
- PlayerViewController 추가 시 addChild() 호출 누락 수정
- removePlayerViewController에서 뷰 컨트롤러를 올바르게 제거하도록 수정
- 메모리 누수 방지 및 뷰 컨트롤러 라이프사이클 메서드 정상 호출 보장

## Test plan
- [x] 음악 플레이어 열기/닫기 시 크래시가 발생하지 않는지 확인
- [x] 메모리 누수가 발생하지 않는지 테스트
- [x] 뷰 컨트롤러 라이프사이클 메서드가 정상적으로 호출되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)