### PR TITLE
fix: 비공개 API 사용 제거

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Extension/UI/UINavigationItem.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Extension/UI/UINavigationItem.swift
@@ -10,7 +10,9 @@ import UIKit
 extension UINavigationItem {
 
     func enableMultilineTitle() {
-        setValue(true, forKey: "__largeTitleTwoLineMode")
+        // 비공개 API 사용 제거
+        // setValue(true, forKey: "__largeTitleTwoLineMode")는 앱스토어 거절 위험
+        // 다줄 타이틀이 필요한 경우 공개 API 사용 또는 커스텀 뷰 구현 필요
     }
 
 }


### PR DESCRIPTION
## Summary
- UINavigationItem에서 __largeTitleTwoLineMode 비공개 API 사용 제거
- 앱스토어 거절 위험 및 향후 iOS 버전 크래시 가능성 해결
- enableMultilineTitle 메서드는 호환성을 위해 유지하되 비공개 API 호출 제거

## Test plan
- [ ] 앱이 정상적으로 빌드되고 실행되는지 확인
- [ ] 네비게이션 타이틀 관련 기능이 크래시 없이 작동하는지 테스트
- [ ] 앱스토어 심사 통과 가능성 확인

🤖 Generated with [Claude Code](https://claude.ai/code)