### PR TITLE
fix: 반구 데이터 복사 실수 수정

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/EntityMapping/ItemEntity+Mapping.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/EntityMapping/ItemEntity+Mapping.swift
@@ -151,9 +151,9 @@ extension Hemispheres {
                 "monthsArray": north.monthsArray
             ],
             "south": [
-                "time": north.time,
-                "months": north.months,
-                "monthsArray": north.monthsArray
+                "time": south.time,
+                "months": south.months,
+                "monthsArray": south.monthsArray
             ]
         ]
     }


### PR DESCRIPTION
## Summary
- Hemispheres.toDictionary()에서 남반구 데이터에 북반구 값이 사용되던 문제 수정
- south 키의 데이터가 north 데이터로 잘못 매핑되던 버그 해결
- 남반구 유저에게 올바른 시간/월/월배열 데이터가 표시되도록 수정

## Test plan
- [ ] 남반구 설정으로 생물 출현 시간이 올바르게 표시되는지 확인
- [ ] 북반구와 남반구의 데이터가 다르게 표시되는지 테스트
- [ ] CoreData에 올바른 반구 데이터가 저장되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)