### PR TITLE
fix: 한글 하드코딩 에러 메시지 현지화 및 오타 수정

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -1511,3 +1511,11 @@ Find the villagers you have visited and tap the home icon on the villager's page
 "time" = "Time";
 "conditions" = "Conditions";
 "features" = "Features";
+
+// MARK: - API Error Messages
+"api_error_response_casting" = "Response casting failed.";
+"api_error_status_code" = "Status code error: %d\nError message: %@";
+"api_error_not_found_url" = "URL not found.";
+"api_error_invalid_data" = "Invalid data.";
+"api_error_invalid_url" = "Invalid URL.\nURL: %@";
+"api_error_parsing" = "Unknown error occurred while parsing JSON.";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -1515,3 +1515,11 @@
 "time" = "시간";
 "conditions" = "조건";
 "features" = "특징";
+
+// MARK: - API Error Messages
+"api_error_response_casting" = "캐스팅에 실패하였습니다.";
+"api_error_status_code" = "상태 코드 에러 : %d\n 오류 메세지 : %@";
+"api_error_not_found_url" = "URL을 찾을 수 없습니다.";
+"api_error_invalid_data" = "데이터가 유효하지 않습니다.";
+"api_error_invalid_url" = "URL이 잘못되었습니다.\nURL: %@";
+"api_error_parsing" = "JSON으로 파싱하는 도중 알 수 없는 오류가 발생했습니다.";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/DailyTask.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/DailyTask.swift
@@ -107,7 +107,7 @@ extension DailyTask {
                 createdDate: Date(timeIntervalSince1970: 1654614000.0)
             ),
             DailyTask(
-                name: "Find peral",
+                name: "Find pearl",
                 icon: "Inv199",
                 isCompleted: false,
                 amount: 1,

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Utilities/APIError.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Networking/Utilities/APIError.swift
@@ -18,17 +18,17 @@ enum APIError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .responseCasting:
-            return "캐스팅에 실패하였습니다."
+            return NSLocalizedString("api_error_response_casting", comment: "Response casting failed")
         case .statusCode(let code, let message):
-            return "상태 코드 에러 : \(code)\n 오류 메세지 : \(message)"
+            return String(format: NSLocalizedString("api_error_status_code", comment: "Status code error"), code, message)
         case .notFoundURL:
-            return "URL을 찾을 수 없습니다."
+            return NSLocalizedString("api_error_not_found_url", comment: "URL not found")
         case .invalidData:
-            return "데이터가 유효하지 않습니다."
+            return NSLocalizedString("api_error_invalid_data", comment: "Invalid data")
         case .invalidURL(let url):
-            return "URL이 잘못되었습니다.\nURL: \(url)"
+            return String(format: NSLocalizedString("api_error_invalid_url", comment: "Invalid URL"), url)
         case .parsingError:
-            return "JSON으로 파싱하는 도중 알 수 없는 오류가 발생했습니다."
+            return NSLocalizedString("api_error_parsing", comment: "JSON parsing error")
         }
     }
 }


### PR DESCRIPTION
## Summary
- APIError 메시지를 NSLocalizedString으로 변경하여 다국어 지원 개선
- 한국어/영어 Localizable.strings에 API 에러 메시지 추가
- DailyTask에서 "Find peral" → "Find pearl" 오타 수정

## Test plan
- [x] 한국어 로케일에서 에러 메시지 확인
- [x] 영어 로케일에서 에러 메시지 확인  
- [x] DailyTask 오타 수정 확인

🤖 Generated with [Claude Code](https://claude.ai/code)