### PR TITLE
fix: 다국어 문자열 키값을 모두 소문자로 통일

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -7,15 +7,16 @@
 */
 
 // MARK: - Tab Bar Titles
-"Dashboard" = "Dashboard";
-"Catalog" = "Catalog";
+"dashboard" = "Dashboard";
+"catalog" = "Catalog";
 "villagers" = "Villagers";
-"Collection" = "Collection";
+"collection" = "Collection";
 "animals" = "Animals";
 
 // MARK: - etc
-"Cancel" = "Cancel";
-"Setting" = "Setting";
+"cancel" = "Cancel";
+"ok" = "OK";
+"setting" = "Setting";
 
 // MARK: - DashboardViewContrller - section title
 "My Island" = "My Island";
@@ -29,9 +30,9 @@
 "Please set a name." = "Please set a name.";
 "Please set a Island Name." = "Please set a Island Name.";
 "Please set a Hemisphere." = "Please set a Hemisphere.";
-"USER" = "USER";
-"FRUIT" = "FRUIT";
-"REPUTATION" = "REPUTATION";
+"user" = "USER";
+"fruit" = "FRUIT";
+"reputation" = "REPUTATION";
 
 // MARK: - TodaysTasksView
 "Edit" = "Edit";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -7,15 +7,16 @@
 */
 
 // MARK: - Tab Bar Titles
-"Dashboard" = "대시보드";
-"Catalog" = "카탈로그";
+"dashboard" = "대시보드";
+"catalog" = "카탈로그";
 "villagers" = "마을주민";
-"Collection" = "수집품";
+"collection" = "수집품";
 "animals" = "동물";
 
 // MARK: - etc
-"Cancel" = "취소";
-"Setting" = "앱 기본 설정";
+"cancel" = "취소";
+"ok" = "확인";
+"setting" = "앱 기본 설정";
 
 // MARK: - DashboardViewContrller - section title
 "My Island" = "나의 섬 정보";
@@ -29,9 +30,9 @@
 "Please set a name." = "이름을 설정해주세요.";
 "Please set a Island Name." = "섬 이름을 설정해주세요.";
 "Please set a Hemisphere." = "반구를 설정해주세요.";
-"USER" = "주민 대표";
-"FRUIT" = "과일";
-"REPUTATION" = "섬 평판";
+"user" = "주민 대표";
+"fruit" = "과일";
+"reputation" = "섬 평판";
 
 // MARK: - TodaysTasksView
 "Edit" = "편집";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/AppCoordinator.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/AppCoordinator.swift
@@ -23,13 +23,13 @@ final class AppCoordinator: Coordinator {
         let dashboardCoordinator = DashboardCoordinator()
         dashboardCoordinator.start()
         dashboardCoordinator.setUpParent(to: self)
-        addViewController(dashboardCoordinator.rootViewController, title: "Dashboard".localized, icon: "icon-bells-tabbar")
+        addViewController(dashboardCoordinator.rootViewController, title: "dashboard".localized, icon: "icon-bells-tabbar")
         childCoordinators.append(dashboardCoordinator)
 
         let catalogCoordinator = CatalogCoordinator()
         catalogCoordinator.start()
         catalogCoordinator.setUpParent(to: self)
-        addViewController(catalogCoordinator.rootViewController, title: "Catalog".localized, icon: "icon-leaf-tabbar")
+        addViewController(catalogCoordinator.rootViewController, title: "catalog".localized, icon: "icon-leaf-tabbar")
         childCoordinators.append(catalogCoordinator)
 
         let animalsCoordinator = AnimalsCoordinator()
@@ -40,7 +40,7 @@ final class AppCoordinator: Coordinator {
         let collectionCoordinator = CollectionCoordinator()
         collectionCoordinator.start()
         collectionCoordinator.setUpParent(to: self)
-        addViewController(collectionCoordinator.rootViewController, title: "Collection".localized, icon: "icon-cardboard-tabbar")
+        addViewController(collectionCoordinator.rootViewController, title: "collection".localized, icon: "icon-cardboard-tabbar")
         childCoordinators.append(collectionCoordinator)
     }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Extension/UI/UIViewController+extension.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Extension/UI/UIViewController+extension.swift
@@ -27,7 +27,7 @@ extension UIViewController {
                 )
             }
             alert.addAction(
-                UIAlertAction(title: "Cancel".localized, style: .cancel) { _ in
+                UIAlertAction(title: "cancel".localized, style: .cancel) { _ in
                     alert.dismiss(animated: true)
                 }
             )
@@ -54,14 +54,14 @@ extension UIViewController {
         return Observable.create { observer in
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addAction(
-                UIAlertAction(title: "Cancel".localized, style: .destructive) { _ in
+                UIAlertAction(title: "cancel".localized, style: .destructive) { _ in
                     alert.dismiss(animated: true)
                     observer.onNext(false)
                     observer.onCompleted()
                 }
             )
             alert.addAction(
-                UIAlertAction(title: "OK".localized, style: .default) { _ in
+                UIAlertAction(title: "ok".localized, style: .default) { _ in
                     alert.dismiss(animated: true)
                     observer.onNext(true)
                     observer.onCompleted()

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/UserInfoView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/UserInfoView.swift
@@ -56,10 +56,10 @@ final class UserInfoView: UIView {
         addSubviews(backgroundStackView)
         backgroundStackView.addArrangedSubviews(
             InfoContentView(title: "island".localized.uppercased(), contentView: islandNameLabel),
-            InfoContentView(title: "REPUTATION".localized, contentView: reputationLabel),
-            InfoContentView(title: "USER".localized, contentView: userNameLabel),
+            InfoContentView(title: "reputation".localized.uppercased(), contentView: reputationLabel),
+            InfoContentView(title: "user".localized.uppercased(), contentView: userNameLabel),
             InfoContentView(title: "hemisphere".localized.uppercased(), contentView: hemisphereLabel),
-            InfoContentView(title: "FRUIT".localized, contentView: fruitImageView)
+            InfoContentView(title: "fruit".localized.uppercased(), contentView: fruitImageView)
 
         )
 


### PR DESCRIPTION
## Summary
- 다국어 문자열 키값들을 모두 소문자로 변경하여 일관성 확보
- 탭바 제목, 버튼 텍스트, 사용자 정보 관련 키들을 소문자로 통일
- 관련 Swift 코드에서 키 사용 부분도 동기화

## Changes
- **한국어/영어 Localizable.strings**: 주요 키들을 소문자로 변경
- **AppCoordinator.swift**: 탭바 제목 키들을 소문자로 수정
- **UIViewController+extension.swift**: 버튼 키들을 소문자로 수정
- **UserInfoView.swift**: 사용자 정보 키들을 소문자로 수정

## Test plan
- [x] 탭바 제목이 올바르게 표시되는지 확인
- [x] 알림창 버튼 텍스트가 올바르게 표시되는지 확인
- [x] 사용자 정보 섹션 라벨이 올바르게 표시되는지 확인

Closes #70

🤖 Generated with [Claude Code](https://claude.ai/code)