### PR TITLE
[홈/오늘의할일] 아이콘 선택 페이지에서 진주 아이콘 보이지 않던 문제 개선

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/IconChooserViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/IconChooserViewController.swift
@@ -12,7 +12,7 @@ final class IconChooserViewController: UIViewController {
     weak var coordinator: DashboardCoordinator?
 
     private let itemSize = 50
-    private let iconCount = 199
+    private let iconCount = 200
 
     private lazy var collectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()


### PR DESCRIPTION
### 📕 Issue

fix #108


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 진주 아이콘이 보여질 수 있도록 컬렉션뷰 총 아이콘 갯수 정정

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 사용자 가이드 업데이트가 필요한가?
  - [x] 사용자 가이드를 업데이트 하였는가?
