### PR TITLE
[대시보드] 대시보드에서 마을주민, NPC를 체크해제 시 이상동작 문제를 개선

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/NpcsSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/NpcsSectionReactor.swift
@@ -14,15 +14,20 @@ final class NpcsSectionReactor: Reactor, ObservableObject {
     enum Action {
         case fetch
         case npcLongPress(index: Int)
+        case npcChecked(index: Int)
+        case resetCheckedNpcs
     }
 
     enum Mutation {
         case transition(route: DashboardCoordinator.Route)
         case setNpc(_ npcs: [NPC])
+        case setCheckedNpc(_ npc: NPC)
+        case resetCheckedNpcs
     }
 
     struct State {
         var npcs: [NPC] = []
+        var checkedNpcs: [NPC] = []
     }
 
     @Published var initialState: State
@@ -47,6 +52,15 @@ final class NpcsSectionReactor: Reactor, ObservableObject {
                 return Observable.empty()
             }
             return Observable.just(Mutation.transition(route: .npcDetail(npc: npc)))
+
+        case .npcChecked(let index):
+            guard let npc = currentState.npcs[safe: index] else {
+                return .empty()
+            }
+            return .just(Mutation.setCheckedNpc(npc))
+
+        case .resetCheckedNpcs:
+            return .just(Mutation.resetCheckedNpcs)
         }
     }
 
@@ -59,6 +73,16 @@ final class NpcsSectionReactor: Reactor, ObservableObject {
         case let .setNpc(npcs):
             newState.npcs = npcs
             objectWillChange.send()
+
+        case let .setCheckedNpc(npc):
+            if let index = newState.checkedNpcs.firstIndex(where: { $0.name == npc.name }) {
+                newState.checkedNpcs.remove(at: index)
+            } else {
+                newState.checkedNpcs.append(npc)
+            }
+
+        case .resetCheckedNpcs:
+            newState.checkedNpcs = []
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/shared/IconCell.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/shared/IconCell.swift
@@ -38,11 +38,9 @@ final class IconCell: UICollectionViewCell {
         checkImage?.removeFromSuperview()
     }
 
-    func checkMark() {
-        guard imageView.subviews.count <= 1 else {
-            removeCheckMark()
-            return
-        }
+    func setChecked(_ isChecked: Bool) {
+        removeCheckMark()
+        guard isChecked else { return }
         let checkImage = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
         checkImage.tintColor = .acHeaderBackground
         checkImage.backgroundColor = .white
@@ -55,5 +53,9 @@ final class IconCell: UICollectionViewCell {
             checkImage.widthAnchor.constraint(equalToConstant: 20),
             checkImage.heightAnchor.constraint(equalToConstant: 20)
         ])
+    }
+
+    func checkMark() {
+        setChecked(true)
     }
 }


### PR DESCRIPTION
### 📕 Issue

fix _ISSUE_URL_


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- 문제: 
	- VillagersView와 NpcsView에서 collectionView.rx.itemSelected로 셀을 탭할 때 체크 표시가 사라지거나 엉뚱한 셀에 나타남.
- 원인: 
	- 뷰에서 UI를 직접 토글(cell?.checkMark())하고, 셀 바인딩도 상태 스냅샷 기반 토글을 중복 호출해 재사용 시 체크 제거/중복 삽입이 뒤섞임 (IconCell.checkMark()가 토글 동작).
- 해결: 
	- 체크 여부를 전적으로 상태(checkedVillagers, checkedNpcs)로 관리하고, 
	- 셀 바인딩에서 (모델, isChecked)로 setChecked를 적용하도록 변경. 
	- 탭/리셋 시에는 액션만 보내 상태를 갱신하며 UI 반영은 바인딩에 맡김 
	- (VillagersView.swift, NpcsView.swift, IconCell.swift, NpcsSectionReactor.swift).


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
