### PR TITLE
✨ [feat] 대시보드 뮤직 플레이어 섹션 추가 (#20)

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "Now Playing" = "Now Playing";
 "No song playing" = "No song playing";
 "Tap to start playing K.K. songs" = "Tap to start playing K.K. songs";
+"Loading songs..." = "Loading songs...";
 "Residents who can visit randomly on weekdays" = "Residents who can visit randomly on weekdays";
 "Residents who visit regularly" = "Residents who visit regularly";
 

--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,9 @@
 "Today's Tasks" = "Today's Tasks";
 "My Villagers" = "My Villagers";
 "Collection Progress" = "Collection Progress";
+"Now Playing" = "Now Playing";
+"No song playing" = "No song playing";
+"Tap to start playing K.K. songs" = "Tap to start playing K.K. songs";
 "Residents who can visit randomly on weekdays" = "Residents who can visit randomly on weekdays";
 "Residents who visit regularly" = "Residents who visit regularly";
 

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "Now Playing" = "지금 재생 중";
 "No song playing" = "재생 중인 곡 없음";
 "Tap to start playing K.K. songs" = "K.K. 슬라이더 음악을 재생하려면 탭하세요";
+"Loading songs..." = "노래 불러오는 중...";
 "Residents who can visit randomly on weekdays" = "평일에 랜덤하게 방문할 수 있는 주민";
 "Residents who visit regularly" = "고정으로 방문하는 주민";
 

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -22,6 +22,9 @@
 "Today's Tasks" = "오늘의 할일";
 "My Villagers" = "마을 주민";
 "Collection Progress" = "수집 현황";
+"Now Playing" = "지금 재생 중";
+"No song playing" = "재생 중인 곡 없음";
+"Tap to start playing K.K. songs" = "K.K. 슬라이더 음악을 재생하려면 탭하세요";
 "Residents who can visit randomly on weekdays" = "평일에 랜덤하게 방문할 수 있는 주민";
 "Residents who visit regularly" = "고정으로 방문하는 주민";
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
@@ -46,7 +46,8 @@ final class DashboardCoordinator: Coordinator {
             villagersVM: VillagersSectionReactor(coordinator: self),
             progressVM: CollectionProgressSectionReactor(coordinator: self),
             fixeVisitdNPCListVM: NpcsSectionReactor(state: .init(), mode: .fixedVisit, coordinator: self),
-            randomVisitNPCListVM: NpcsSectionReactor(state: .init(), mode: .randomVisit, coordinator: self)
+            randomVisitNPCListVM: NpcsSectionReactor(state: .init(), mode: .randomVisit, coordinator: self),
+            musicPlayerVM: MusicPlayerSectionReactor()
         )
         rootViewController.addChild(viewController)
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
@@ -63,7 +63,8 @@ final class DashboardViewController: UIViewController {
         villagersVM: VillagersSectionReactor,
         progressVM: CollectionProgressSectionReactor,
         fixeVisitdNPCListVM: NpcsSectionReactor,
-        randomVisitNPCListVM: NpcsSectionReactor
+        randomVisitNPCListVM: NpcsSectionReactor,
+        musicPlayerVM: MusicPlayerSectionReactor
     ) {
         let userInfoSection = SectionView(
             title: "My Island".localized,
@@ -85,6 +86,11 @@ final class DashboardViewController: UIViewController {
             iconName: "chart.pie.fill",
             contentView: CollectionProgressView(viewModel: progressVM)
         )
+        let musicPlayerSection = SectionView(
+            title: "Now Playing".localized,
+            iconName: "music.note",
+            contentView: MusicPlayerSectionView(musicPlayerVM)
+        )
         let randomVisitResidentsSectionView = SectionView(
             title: "Residents who can visit randomly on weekdays".localized,
             iconName: "bubbles.and.sparkles.fill",
@@ -96,10 +102,11 @@ final class DashboardViewController: UIViewController {
             contentView: NpcsView(fixeVisitdNPCListVM)
         )
         sectionsScrollView.addSection(userInfoSection,
-                                      tasksSection, 
-                                      villagersSection, 
-                                      progressSection, 
-                                      randomVisitResidentsSectionView, 
+                                      tasksSection,
+                                      villagersSection,
+                                      progressSection,
+                                      musicPlayerSection,
+                                      randomVisitResidentsSectionView,
                                       fixedVisitResidentsSectionView)
     }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/MusicPlayerSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/MusicPlayerSectionReactor.swift
@@ -1,0 +1,84 @@
+//
+//  MusicPlayerSectionReactor.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2025/01/01.
+//
+
+import Foundation
+import ReactorKit
+
+final class MusicPlayerSectionReactor: Reactor {
+
+    enum Action {
+        case playPauseTapped
+        case previousTapped
+        case nextTapped
+    }
+
+    enum Mutation {
+        case setCurrentSong(Item?)
+        case setIsPlaying(Bool)
+        case setProgress(Float)
+    }
+
+    struct State {
+        var currentSong: Item?
+        var isPlaying: Bool = false
+        var progress: Float = 0
+    }
+
+    let initialState: State = State()
+    private let musicPlayerManager: MusicPlayerManager
+
+    init(musicPlayerManager: MusicPlayerManager = .shared) {
+        self.musicPlayerManager = musicPlayerManager
+    }
+
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let currentSongMutation = musicPlayerManager.currentMusic
+            .map { Mutation.setCurrentSong($0) }
+
+        let isPlayingMutation = musicPlayerManager.isNowPlaying
+            .map { Mutation.setIsPlaying($0 ?? false) }
+
+        let progressMutation = musicPlayerManager.songProgress
+            .map { Mutation.setProgress($0) }
+
+        return Observable.merge(
+            mutation,
+            currentSongMutation,
+            isPlayingMutation,
+            progressMutation
+        )
+    }
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .playPauseTapped:
+            musicPlayerManager.togglePlaying()
+            return .empty()
+
+        case .previousTapped:
+            musicPlayerManager.prev()
+            return .empty()
+
+        case .nextTapped:
+            musicPlayerManager.next()
+            return .empty()
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setCurrentSong(let song):
+            newState.currentSong = song
+        case .setIsPlaying(let isPlaying):
+            newState.isPlaying = isPlaying
+        case .setProgress(let progress):
+            newState.progress = progress
+        }
+        return newState
+    }
+}

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/MusicPlayerSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/MusicPlayerSectionReactor.swift
@@ -20,12 +20,14 @@ final class MusicPlayerSectionReactor: Reactor {
         case setCurrentSong(Item?)
         case setIsPlaying(Bool)
         case setProgress(Float)
+        case setSongsAvailable(Bool)
     }
 
     struct State {
         var currentSong: Item?
         var isPlaying: Bool = false
         var progress: Float = 0
+        var isSongsAvailable: Bool = false
     }
 
     let initialState: State = State()
@@ -45,11 +47,15 @@ final class MusicPlayerSectionReactor: Reactor {
         let progressMutation = musicPlayerManager.songProgress
             .map { Mutation.setProgress($0) }
 
+        let songsAvailableMutation = musicPlayerManager.songList
+            .map { Mutation.setSongsAvailable(!$0.isEmpty) }
+
         return Observable.merge(
             mutation,
             currentSongMutation,
             isPlayingMutation,
-            progressMutation
+            progressMutation,
+            songsAvailableMutation
         )
     }
 
@@ -78,6 +84,8 @@ final class MusicPlayerSectionReactor: Reactor {
             newState.isPlaying = isPlaying
         case .setProgress(let progress):
             newState.progress = progress
+        case .setSongsAvailable(let isAvailable):
+            newState.isSongsAvailable = isAvailable
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/MusicPlayerSectionView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/MusicPlayerSectionView.swift
@@ -1,0 +1,241 @@
+//
+//  MusicPlayerSectionView.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2025/01/01.
+//
+
+import UIKit
+import RxSwift
+
+final class MusicPlayerSectionView: UIView {
+
+    private let disposeBag = DisposeBag()
+
+    private lazy var backgroundStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 16
+        return stackView
+    }()
+
+    private lazy var albumCoverImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .tertiarySystemFill
+        imageView.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).isActive = true
+        return imageView
+    }()
+
+    private lazy var infoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        stackView.spacing = 4
+        return stackView
+    }()
+
+    private lazy var songTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(for: .body, weight: .semibold)
+        label.textColor = .acText
+        label.numberOfLines = 1
+        label.text = "No song playing".localized
+        return label
+    }()
+
+    private lazy var artistLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        label.text = "K.K. Slider"
+        return label
+    }()
+
+    private lazy var controlsStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    private lazy var previousButton: UIButton = {
+        let button = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+        button.setImage(UIImage(systemName: "backward.fill")?.withConfiguration(config), for: .normal)
+        button.tintColor = .acText
+        button.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        return button
+    }()
+
+    private lazy var playPauseButton: UIButton = {
+        let button = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+        button.setImage(UIImage(systemName: "play.fill")?.withConfiguration(config), for: .normal)
+        button.tintColor = .acText
+        button.widthAnchor.constraint(equalToConstant: 44).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        return button
+    }()
+
+    private lazy var nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+        button.setImage(UIImage(systemName: "forward.fill")?.withConfiguration(config), for: .normal)
+        button.tintColor = .acText
+        button.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        return button
+    }()
+
+    private lazy var progressView: UIProgressView = {
+        let progressView = UIProgressView(progressViewStyle: .default)
+        progressView.progressTintColor = .acHeaderBackground
+        progressView.trackTintColor = .tertiarySystemFill
+        progressView.layer.cornerRadius = 2
+        progressView.clipsToBounds = true
+        return progressView
+    }()
+
+    private lazy var emptyStateView: UIView = {
+        let view = UIView()
+        view.isHidden = true
+
+        let label = UILabel()
+        label.text = "Tap to start playing K.K. songs".localized
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+
+        view.addSubviews(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        return view
+    }()
+
+    private lazy var contentView: UIView = {
+        let view = UIView()
+        return view
+    }()
+
+    private func configure() {
+        addSubviews(contentView, emptyStateView)
+        contentView.addSubviews(backgroundStackView, progressView)
+
+        infoStackView.addArrangedSubviews(songTitleLabel, artistLabel)
+        controlsStackView.addArrangedSubviews(previousButton, playPauseButton, nextButton)
+        backgroundStackView.addArrangedSubviews(albumCoverImageView, infoStackView, controlsStackView)
+
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+
+            backgroundStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            backgroundStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            backgroundStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+
+            progressView.topAnchor.constraint(equalTo: backgroundStackView.bottomAnchor, constant: 12),
+            progressView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            progressView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            progressView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            progressView.heightAnchor.constraint(equalToConstant: 4),
+
+            emptyStateView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            emptyStateView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            emptyStateView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            emptyStateView.heightAnchor.constraint(equalToConstant: 60)
+        ])
+    }
+
+    private func bind(to reactor: MusicPlayerSectionReactor) {
+        // Actions
+        playPauseButton.rx.tap
+            .map { MusicPlayerSectionReactor.Action.playPauseTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        previousButton.rx.tap
+            .map { MusicPlayerSectionReactor.Action.previousTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        nextButton.rx.tap
+            .map { MusicPlayerSectionReactor.Action.nextTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        let tapGesture = UITapGestureRecognizer()
+        emptyStateView.addGestureRecognizer(tapGesture)
+        tapGesture.rx.event
+            .map { _ in MusicPlayerSectionReactor.Action.playPauseTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        // States
+        reactor.state
+            .map { $0.currentSong }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] song in
+                if let song = song {
+                    self?.songTitleLabel.text = song.translations.localizedName()
+                    self?.albumCoverImageView.setImage(with: song.image ?? "")
+                    self?.contentView.isHidden = false
+                    self?.emptyStateView.isHidden = true
+                } else {
+                    self?.songTitleLabel.text = "No song playing".localized
+                    self?.albumCoverImageView.image = nil
+                    self?.contentView.isHidden = true
+                    self?.emptyStateView.isHidden = false
+                }
+            }).disposed(by: disposeBag)
+
+        reactor.state
+            .map { $0.isPlaying }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isPlaying in
+                let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+                let imageName = isPlaying ? "pause.fill" : "play.fill"
+                self?.playPauseButton.setImage(
+                    UIImage(systemName: imageName)?.withConfiguration(config),
+                    for: .normal
+                )
+            }).disposed(by: disposeBag)
+
+        reactor.state
+            .map { $0.progress }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] progress in
+                self?.progressView.setProgress(progress, animated: true)
+            }).disposed(by: disposeBag)
+    }
+}
+
+extension MusicPlayerSectionView {
+    convenience init(_ reactor: MusicPlayerSectionReactor) {
+        self.init(frame: .zero)
+        configure()
+        bind(to: reactor)
+    }
+}


### PR DESCRIPTION
## Summary
- 대시보드에 현재 재생 중인 K.K. 슬라이더 음악을 표시하는 미니 플레이어 섹션 추가
- MusicPlayerSectionView: 앨범 커버, 곡 제목, 재생/일시정지/다음/이전 버튼 구현
- MusicPlayerSectionReactor: ReactorKit 기반 상태 관리로 MusicPlayerManager.shared와 연동

## Changes
- `MusicPlayerSectionView.swift`: 미니 플레이어 UI 구현
- `MusicPlayerSectionReactor.swift`: 재생 상태 관리 Reactor
- `DashboardViewController.swift`: 뮤직 플레이어 섹션 추가
- `DashboardCoordinator.swift`: MusicPlayerSectionReactor 초기화 추가
- `Localizable.strings` (en/ko): 관련 문자열 추가

## Test plan
- [ ] 대시보드에서 뮤직 플레이어 섹션이 표시되는지 확인
- [ ] 재생/일시정지 버튼 동작 확인
- [ ] 이전/다음 트랙 버튼 동작 확인
- [ ] 곡 재생 시 앨범 커버, 곡 제목이 업데이트되는지 확인
- [ ] 프로그레스 바가 재생 진행에 따라 업데이트되는지 확인
- [ ] 음악이 재생되지 않을 때 empty 상태 표시 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)