### PR TITLE
✨ [feat] 네트워크 재시도 기능 추가 (#40)

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/Networking/DefaultAPIProvider.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Networking/DefaultAPIProvider.swift
@@ -10,15 +10,186 @@ import Alamofire
 import OSLog
 
 struct DefaultAPIProvider: APIProvider {
-    func request<T: APIRequest>(_ request: T, completion: @escaping (Result<T.Response, Error>) -> Void) {
-        AF.request(request).responseDecodable(of: T.Response.self) { data in
-            switch data.result {
-            case .success(let response):
-                completion(.success(response))
+
+    // MARK: - Configuration
+    struct RetryConfiguration {
+        /// 최대 재시도 횟수
+        let maxRetries: Int
+        /// 기본 지연 시간 (초)
+        let baseDelay: TimeInterval
+        /// 최대 지연 시간 (초)
+        let maxDelay: TimeInterval
+        /// 네트워크 복구 시 자동 재시도 활성화
+        let enableAutoRetryOnReconnect: Bool
+
+        static let `default` = RetryConfiguration(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxDelay: 30.0,
+            enableAutoRetryOnReconnect: true
+        )
+    }
+
+    private let networkMonitor: NetworkMonitor
+    private let configuration: RetryConfiguration
+
+    // MARK: - Initialization
+    init(
+        networkMonitor: NetworkMonitor = .shared,
+        configuration: RetryConfiguration = .default
+    ) {
+        self.networkMonitor = networkMonitor
+        self.configuration = configuration
+    }
+
+    // MARK: - APIProvider
+    func request<T: APIRequest>(
+        _ request: T,
+        completion: @escaping (Result<T.Response, Error>) -> Void
+    ) {
+        requestWithRetry(request, retryCount: 0, completion: completion)
+    }
+
+    // MARK: - Private Methods
+
+    /// 재시도 로직이 포함된 요청 메서드
+    private func requestWithRetry<T: APIRequest>(
+        _ request: T,
+        retryCount: Int,
+        completion: @escaping (Result<T.Response, Error>) -> Void
+    ) {
+        // 네트워크 연결 확인
+        guard networkMonitor.isConnected else {
+            handleNetworkUnavailable(request, completion: completion)
+            return
+        }
+
+        AF.request(request).responseDecodable(of: T.Response.self) { response in
+            switch response.result {
+            case .success(let data):
+                completion(.success(data))
+
             case .failure(let error):
-                debugPrint(error)
-                completion(.failure(error))
+                self.handleRequestFailure(
+                    request: request,
+                    error: error,
+                    retryCount: retryCount,
+                    completion: completion
+                )
             }
         }
+    }
+
+    /// 네트워크 연결이 없을 때 처리
+    private func handleNetworkUnavailable<T: APIRequest>(
+        _ request: T,
+        completion: @escaping (Result<T.Response, Error>) -> Void
+    ) {
+        os_log(
+            .info,
+            log: .default,
+            "Network unavailable - enqueueing request for retry: %@",
+            String(describing: T.self)
+        )
+
+        if configuration.enableAutoRetryOnReconnect {
+            // 네트워크 복구 시 자동 재시도를 위해 대기 큐에 추가
+            networkMonitor.enqueuePendingRequest(maxRetries: configuration.maxRetries) { [self] in
+                self.request(request, completion: completion)
+            }
+        }
+
+        completion(.failure(APIError.networkUnavailable))
+    }
+
+    /// 요청 실패 처리
+    private func handleRequestFailure<T: APIRequest>(
+        request: T,
+        error: AFError,
+        retryCount: Int,
+        completion: @escaping (Result<T.Response, Error>) -> Void
+    ) {
+        let apiError = mapToAPIError(error)
+
+        // 재시도 가능한 에러인지 확인
+        guard shouldRetry(error: apiError, retryCount: retryCount) else {
+            logFailure(request: request, error: error, retryCount: retryCount, willRetry: false)
+
+            if retryCount > 0 {
+                completion(.failure(APIError.retryExhausted(originalError: error)))
+            } else {
+                completion(.failure(error))
+            }
+            return
+        }
+
+        logFailure(request: request, error: error, retryCount: retryCount, willRetry: true)
+
+        // 지수 백오프 적용
+        let delay = calculateBackoffDelay(retryCount: retryCount)
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+            self.requestWithRetry(request, retryCount: retryCount + 1, completion: completion)
+        }
+    }
+
+    /// 재시도 여부 결정
+    private func shouldRetry(error: APIError?, retryCount: Int) -> Bool {
+        guard retryCount < configuration.maxRetries else { return false }
+        guard let error = error else { return false }
+        return error.isRetryable
+    }
+
+    /// AFError를 APIError로 변환
+    private func mapToAPIError(_ error: AFError) -> APIError? {
+        switch error {
+        case .sessionTaskFailed(let urlError as URLError):
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .cannotConnectToHost:
+                return .networkUnavailable
+            case .timedOut:
+                return .statusCode(code: 408, message: "Request Timeout")
+            default:
+                return nil
+            }
+
+        case .responseValidationFailed(let reason):
+            if case .unacceptableStatusCode(let code) = reason {
+                return .statusCode(code: code, message: "HTTP \(code)")
+            }
+            return nil
+
+        default:
+            return nil
+        }
+    }
+
+    /// 지수 백오프 지연 시간 계산
+    private func calculateBackoffDelay(retryCount: Int) -> TimeInterval {
+        let exponentialDelay = configuration.baseDelay * pow(2.0, Double(retryCount))
+        // 무작위 지터(jitter) 추가로 thundering herd 문제 방지
+        let jitter = Double.random(in: 0...0.5) * exponentialDelay
+        return min(exponentialDelay + jitter, configuration.maxDelay)
+    }
+
+    /// 실패 로그 기록
+    private func logFailure<T: APIRequest>(
+        request: T,
+        error: Error,
+        retryCount: Int,
+        willRetry: Bool
+    ) {
+        let retryInfo = willRetry
+            ? "Retrying (\(retryCount + 1)/\(configuration.maxRetries))..."
+            : "No more retries."
+
+        os_log(
+            .error,
+            log: .default,
+            "Request failed: %@ - Error: %@ - %@",
+            String(describing: T.self),
+            error.localizedDescription,
+            retryInfo
+        )
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Utility/NetworkMonitor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Utility/NetworkMonitor.swift
@@ -1,0 +1,213 @@
+//
+//  NetworkMonitor.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2026/01/01.
+//
+
+import Foundation
+import Network
+import RxSwift
+import RxRelay
+
+/// 네트워크 연결 상태를 모니터링하고, 실패한 요청을 자동 재시도하는 기능을 제공합니다.
+final class NetworkMonitor {
+
+    // MARK: - Singleton
+    static let shared = NetworkMonitor()
+
+    // MARK: - Types
+    enum ConnectionStatus {
+        case connected
+        case disconnected
+
+        var isConnected: Bool {
+            self == .connected
+        }
+    }
+
+    struct PendingRequest {
+        let id: UUID
+        let execute: () -> Void
+        let createdAt: Date
+        let retryCount: Int
+        let maxRetries: Int
+
+        func incrementRetry() -> PendingRequest {
+            PendingRequest(
+                id: id,
+                execute: execute,
+                createdAt: createdAt,
+                retryCount: retryCount + 1,
+                maxRetries: maxRetries
+            )
+        }
+    }
+
+    // MARK: - Properties
+    private let monitor: NWPathMonitor
+    private let monitorQueue = DispatchQueue(label: "com.animal-crossing-wiki.network-monitor", qos: .utility)
+    private let disposeBag = DisposeBag()
+
+    private let connectionStatusRelay = BehaviorRelay<ConnectionStatus>(value: .connected)
+    private let pendingRequestsRelay = BehaviorRelay<[PendingRequest]>(value: [])
+
+    /// 현재 네트워크 연결 상태
+    var connectionStatus: Observable<ConnectionStatus> {
+        connectionStatusRelay.asObservable().distinctUntilChanged()
+    }
+
+    /// 현재 연결 상태 (동기)
+    var isConnected: Bool {
+        connectionStatusRelay.value.isConnected
+    }
+
+    /// 대기 중인 요청 수
+    var pendingRequestCount: Observable<Int> {
+        pendingRequestsRelay.asObservable().map { $0.count }
+    }
+
+    // MARK: - Configuration
+    struct Configuration {
+        /// 기본 최대 재시도 횟수
+        let maxRetries: Int
+        /// 기본 재시도 지연 시간 (초)
+        let baseDelay: TimeInterval
+        /// 최대 재시도 지연 시간 (초)
+        let maxDelay: TimeInterval
+        /// 대기 요청 만료 시간 (초)
+        let requestTimeout: TimeInterval
+
+        static let `default` = Configuration(
+            maxRetries: 3,
+            baseDelay: 1.0,
+            maxDelay: 30.0,
+            requestTimeout: 300.0 // 5분
+        )
+    }
+
+    private let configuration: Configuration
+
+    // MARK: - Initialization
+    private init(configuration: Configuration = .default) {
+        self.configuration = configuration
+        self.monitor = NWPathMonitor()
+
+        setupMonitoring()
+        setupConnectionRecoveryHandler()
+    }
+
+    // MARK: - Public Methods
+
+    /// 네트워크 모니터링을 시작합니다.
+    func startMonitoring() {
+        monitor.start(queue: monitorQueue)
+    }
+
+    /// 네트워크 모니터링을 중지합니다.
+    func stopMonitoring() {
+        monitor.cancel()
+    }
+
+    /// 실패한 요청을 대기 큐에 추가합니다.
+    /// - Parameters:
+    ///   - execute: 재시도할 요청 클로저
+    ///   - maxRetries: 최대 재시도 횟수 (기본값: Configuration의 maxRetries)
+    /// - Returns: 요청 ID
+    @discardableResult
+    func enqueuePendingRequest(
+        maxRetries: Int? = nil,
+        execute: @escaping () -> Void
+    ) -> UUID {
+        let request = PendingRequest(
+            id: UUID(),
+            execute: execute,
+            createdAt: Date(),
+            retryCount: 0,
+            maxRetries: maxRetries ?? configuration.maxRetries
+        )
+
+        var requests = pendingRequestsRelay.value
+        requests.append(request)
+        pendingRequestsRelay.accept(requests)
+
+        return request.id
+    }
+
+    /// 특정 요청을 대기 큐에서 제거합니다.
+    /// - Parameter id: 제거할 요청의 ID
+    func removePendingRequest(id: UUID) {
+        var requests = pendingRequestsRelay.value
+        requests.removeAll { $0.id == id }
+        pendingRequestsRelay.accept(requests)
+    }
+
+    /// 모든 대기 요청을 제거합니다.
+    func clearPendingRequests() {
+        pendingRequestsRelay.accept([])
+    }
+
+    /// 지수 백오프 지연 시간을 계산합니다.
+    /// - Parameter retryCount: 현재 재시도 횟수
+    /// - Returns: 지연 시간 (초)
+    func calculateBackoffDelay(retryCount: Int) -> TimeInterval {
+        let exponentialDelay = configuration.baseDelay * pow(2.0, Double(retryCount))
+        let jitter = Double.random(in: 0...0.5) * exponentialDelay
+        return min(exponentialDelay + jitter, configuration.maxDelay)
+    }
+
+    // MARK: - Private Methods
+
+    private func setupMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self else { return }
+
+            let status: ConnectionStatus = path.status == .satisfied ? .connected : .disconnected
+
+            DispatchQueue.main.async {
+                self.connectionStatusRelay.accept(status)
+            }
+        }
+    }
+
+    private func setupConnectionRecoveryHandler() {
+        connectionStatus
+            .skip(1) // 초기 값 무시
+            .filter { $0.isConnected }
+            .subscribe(onNext: { [weak self] _ in
+                self?.processPendingRequests()
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func processPendingRequests() {
+        let requests = pendingRequestsRelay.value
+        let validRequests = filterExpiredRequests(requests)
+
+        guard !validRequests.isEmpty else {
+            pendingRequestsRelay.accept([])
+            return
+        }
+
+        // 대기 큐 초기화
+        pendingRequestsRelay.accept([])
+
+        // 각 요청을 지수 백오프로 재시도
+        for (index, request) in validRequests.enumerated() {
+            let delay = calculateBackoffDelay(retryCount: request.retryCount)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay + Double(index) * 0.1) {
+                request.execute()
+            }
+        }
+    }
+
+    private func filterExpiredRequests(_ requests: [PendingRequest]) -> [PendingRequest] {
+        let now = Date()
+        return requests.filter { request in
+            let isNotExpired = now.timeIntervalSince(request.createdAt) < configuration.requestTimeout
+            let hasRetriesLeft = request.retryCount < request.maxRetries
+            return isNotExpired && hasRetriesLeft
+        }.map { $0.incrementRetry() }
+    }
+}


### PR DESCRIPTION
## Summary
- NWPathMonitor를 활용한 네트워크 연결 상태 모니터링 기능 구현
- 실패한 요청을 대기 큐에 저장하고 네트워크 복구 시 자동 재시도
- 지수 백오프(Exponential Backoff) 알고리즘으로 서버 부하 방지

## Changes

### NetworkMonitor.swift (신규)
- `NWPathMonitor`를 활용한 네트워크 연결 상태 실시간 감지
- RxSwift Observable로 연결 상태 스트림 제공
- 실패한 요청 대기 큐 관리 (만료 시간, 최대 재시도 횟수 적용)
- 연결 복구 시 대기 중인 요청 자동 재실행

### DefaultAPIProvider.swift (수정)
- `RetryConfiguration` 구조체로 재시도 설정 관리
- 지수 백오프 + 랜덤 지터(Jitter)로 thundering herd 문제 방지
- 네트워크 연결 상태에 따른 요청 처리 분기
- `AFError`를 `APIError`로 매핑하여 재시도 가능 여부 판단

### APIError.swift (수정)
- `networkUnavailable`: 네트워크 연결 불가 에러
- `retryExhausted`: 최대 재시도 횟수 초과 에러
- `isRetryable` 속성으로 재시도 가능 여부 판단 (5xx, 408, 429 에러)

## Test Plan
- [ ] 비행기 모드에서 앱 실행 시 네트워크 에러 처리 확인
- [ ] 비행기 모드 해제 시 대기 중인 요청 자동 재시도 확인
- [ ] 서버 5xx 에러 발생 시 지수 백오프로 재시도 확인
- [ ] 최대 재시도 횟수 초과 시 `retryExhausted` 에러 반환 확인

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)