### PR TITLE
✨ [feat] 이벤트 캘린더 추가 (#125)

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -1519,3 +1519,29 @@ Find the villagers you have visited and tap the home icon on the villager's page
 "api_error_invalid_data" = "Invalid data.";
 "api_error_invalid_url" = "Invalid URL.\nURL: %@";
 "api_error_parsing" = "Unknown error occurred while parsing JSON.";
+
+// MARK: - Event Calendar
+"Event Calendar" = "Event Calendar";
+"No events this month" = "No events this month";
+"Ongoing" = "Ongoing";
+
+// MARK: - Event Names
+"Fishing Tournament" = "Fishing Tournament";
+"Bug-Off" = "Bug-Off";
+"New Year's Day" = "New Year's Day";
+"Countdown" = "Countdown";
+"Festivale" = "Festivale";
+"Shamrock Day" = "Shamrock Day";
+"Bunny Day" = "Bunny Day";
+"Nature Day" = "Nature Day";
+"May Day" = "May Day";
+"International Museum Day" = "International Museum Day";
+"Wedding Season" = "Wedding Season";
+"Fireworks Show" = "Fireworks Show";
+"Halloween" = "Halloween";
+"Turkey Day" = "Turkey Day";
+"Toy Day" = "Toy Day";
+"Cherry Blossom Season" = "Cherry Blossom Season";
+"Mushroom Season" = "Mushroom Season";
+"Maple Leaf Season" = "Maple Leaf Season";
+"Snowflake Season" = "Snowflake Season";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -1524,3 +1524,29 @@
 "api_error_invalid_data" = "데이터가 유효하지 않습니다.";
 "api_error_invalid_url" = "URL이 잘못되었습니다.\nURL: %@";
 "api_error_parsing" = "JSON으로 파싱하는 도중 알 수 없는 오류가 발생했습니다.";
+
+// MARK: - Event Calendar
+"Event Calendar" = "이벤트 캘린더";
+"No events this month" = "이번 달에는 이벤트가 없습니다";
+"Ongoing" = "진행 중";
+
+// MARK: - Event Names
+"Fishing Tournament" = "낚시 대회";
+"Bug-Off" = "곤충 채집 대회";
+"New Year's Day" = "새해 첫날";
+"Countdown" = "카운트다운";
+"Festivale" = "카니발";
+"Shamrock Day" = "삼잎클로버 데이";
+"Bunny Day" = "부활절";
+"Nature Day" = "자연의 날";
+"May Day" = "메이 데이";
+"International Museum Day" = "세계 박물관의 날";
+"Wedding Season" = "웨딩 시즌";
+"Fireworks Show" = "불꽃놀이 축제";
+"Halloween" = "할로윈";
+"Turkey Day" = "추수감사절";
+"Toy Day" = "토이 데이";
+"Cherry Blossom Season" = "벚꽃 시즌";
+"Mushroom Season" = "버섯 시즌";
+"Maple Leaf Season" = "단풍잎 시즌";
+"Snowflake Season" = "눈꽃 시즌";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/ACNHEvent.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/ACNHEvent.swift
@@ -1,0 +1,383 @@
+//
+//  ACNHEvent.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2024/01/01.
+//
+
+import Foundation
+
+struct ACNHEvent: Equatable {
+    let id: String
+    let name: String
+    let iconName: String
+    let startDate: EventDate
+    let endDate: EventDate?
+    let eventType: EventType
+
+    var isOngoing: Bool {
+        let calendar = Calendar.current
+        let today = Date()
+        let currentMonth = calendar.component(.month, from: today)
+        let currentDay = calendar.component(.day, from: today)
+
+        if let endDate = endDate {
+            // Range event
+            if startDate.month == endDate.month {
+                // Same month
+                return currentMonth == startDate.month &&
+                       currentDay >= startDate.day &&
+                       currentDay <= endDate.day
+            } else if startDate.month < endDate.month {
+                // Different months (same year logic)
+                if currentMonth == startDate.month {
+                    return currentDay >= startDate.day
+                } else if currentMonth == endDate.month {
+                    return currentDay <= endDate.day
+                } else {
+                    return currentMonth > startDate.month && currentMonth < endDate.month
+                }
+            } else {
+                // Year wrap (e.g., December to January)
+                if currentMonth >= startDate.month {
+                    return currentDay >= startDate.day || currentMonth > startDate.month
+                } else if currentMonth <= endDate.month {
+                    return currentDay <= endDate.day || currentMonth < endDate.month
+                }
+                return false
+            }
+        } else {
+            // Single day event
+            return currentMonth == startDate.month && currentDay == startDate.day
+        }
+    }
+
+    var isUpcoming: Bool {
+        let calendar = Calendar.current
+        let today = Date()
+        let currentMonth = calendar.component(.month, from: today)
+        let currentDay = calendar.component(.day, from: today)
+
+        if currentMonth == startDate.month {
+            return currentDay < startDate.day
+        }
+
+        // Check if event is in next 30 days
+        let daysUntilEvent = daysUntil(month: startDate.month, day: startDate.day, from: today)
+        return daysUntilEvent > 0 && daysUntilEvent <= 30
+    }
+
+    private func daysUntil(month: Int, day: Int, from date: Date) -> Int {
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: date)
+
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+
+        guard var eventDate = calendar.date(from: components) else { return 0 }
+
+        if eventDate < date {
+            components.year = year + 1
+            eventDate = calendar.date(from: components) ?? eventDate
+        }
+
+        return calendar.dateComponents([.day], from: date, to: eventDate).day ?? 0
+    }
+
+    var dateDisplayString: String {
+        if let endDate = endDate {
+            return "\(startDate.month)/\(startDate.day) - \(endDate.month)/\(endDate.day)"
+        } else {
+            return "\(startDate.month)/\(startDate.day)"
+        }
+    }
+}
+
+struct EventDate: Equatable {
+    let month: Int
+    let day: Int
+
+    init(month: Int, day: Int) {
+        self.month = month
+        self.day = day
+    }
+}
+
+enum EventType: String, CaseIterable {
+    case fishing = "Fishing Tournament"
+    case bugOff = "Bug-Off"
+    case seasonal = "Seasonal Event"
+    case holiday = "Holiday"
+    case special = "Special Event"
+}
+
+// MARK: - Static Event Data
+extension ACNHEvent {
+
+    static var allEvents: [ACNHEvent] {
+        return [
+            // Fishing Tournaments (2nd Saturday of each month)
+            ACNHEvent(
+                id: "fishing_tournament_jan",
+                name: "Fishing Tournament",
+                iconName: "fish.fill",
+                startDate: EventDate(month: 1, day: 11),
+                endDate: nil,
+                eventType: .fishing
+            ),
+            ACNHEvent(
+                id: "fishing_tournament_apr",
+                name: "Fishing Tournament",
+                iconName: "fish.fill",
+                startDate: EventDate(month: 4, day: 12),
+                endDate: nil,
+                eventType: .fishing
+            ),
+            ACNHEvent(
+                id: "fishing_tournament_jul",
+                name: "Fishing Tournament",
+                iconName: "fish.fill",
+                startDate: EventDate(month: 7, day: 11),
+                endDate: nil,
+                eventType: .fishing
+            ),
+            ACNHEvent(
+                id: "fishing_tournament_oct",
+                name: "Fishing Tournament",
+                iconName: "fish.fill",
+                startDate: EventDate(month: 10, day: 10),
+                endDate: nil,
+                eventType: .fishing
+            ),
+
+            // Bug-Off (3rd Saturday of summer months)
+            ACNHEvent(
+                id: "bug_off_jun",
+                name: "Bug-Off",
+                iconName: "ladybug.fill",
+                startDate: EventDate(month: 6, day: 27),
+                endDate: nil,
+                eventType: .bugOff
+            ),
+            ACNHEvent(
+                id: "bug_off_jul",
+                name: "Bug-Off",
+                iconName: "ladybug.fill",
+                startDate: EventDate(month: 7, day: 25),
+                endDate: nil,
+                eventType: .bugOff
+            ),
+            ACNHEvent(
+                id: "bug_off_aug",
+                name: "Bug-Off",
+                iconName: "ladybug.fill",
+                startDate: EventDate(month: 8, day: 22),
+                endDate: nil,
+                eventType: .bugOff
+            ),
+            ACNHEvent(
+                id: "bug_off_sep",
+                name: "Bug-Off",
+                iconName: "ladybug.fill",
+                startDate: EventDate(month: 9, day: 26),
+                endDate: nil,
+                eventType: .bugOff
+            ),
+
+            // Seasonal Events
+            ACNHEvent(
+                id: "new_years_day",
+                name: "New Year's Day",
+                iconName: "sparkles",
+                startDate: EventDate(month: 1, day: 1),
+                endDate: nil,
+                eventType: .holiday
+            ),
+            ACNHEvent(
+                id: "new_years_eve",
+                name: "Countdown",
+                iconName: "clock.fill",
+                startDate: EventDate(month: 12, day: 31),
+                endDate: nil,
+                eventType: .holiday
+            ),
+            ACNHEvent(
+                id: "festivale",
+                name: "Festivale",
+                iconName: "music.note.list",
+                startDate: EventDate(month: 2, day: 15),
+                endDate: nil,
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "shamrock_day",
+                name: "Shamrock Day",
+                iconName: "leaf.fill",
+                startDate: EventDate(month: 3, day: 17),
+                endDate: nil,
+                eventType: .holiday
+            ),
+            ACNHEvent(
+                id: "bunny_day",
+                name: "Bunny Day",
+                iconName: "hare.fill",
+                startDate: EventDate(month: 4, day: 1),
+                endDate: EventDate(month: 4, day: 12),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "earth_day",
+                name: "Nature Day",
+                iconName: "globe.americas.fill",
+                startDate: EventDate(month: 4, day: 23),
+                endDate: EventDate(month: 5, day: 4),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "may_day",
+                name: "May Day",
+                iconName: "leaf.fill",
+                startDate: EventDate(month: 5, day: 1),
+                endDate: EventDate(month: 5, day: 7),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "international_museum_day",
+                name: "International Museum Day",
+                iconName: "building.columns.fill",
+                startDate: EventDate(month: 5, day: 18),
+                endDate: EventDate(month: 5, day: 31),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "wedding_season",
+                name: "Wedding Season",
+                iconName: "heart.fill",
+                startDate: EventDate(month: 6, day: 1),
+                endDate: EventDate(month: 6, day: 30),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "fireworks_show",
+                name: "Fireworks Show",
+                iconName: "sparkle",
+                startDate: EventDate(month: 8, day: 1),
+                endDate: EventDate(month: 8, day: 31),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "halloween",
+                name: "Halloween",
+                iconName: "theatermasks.fill",
+                startDate: EventDate(month: 10, day: 1),
+                endDate: EventDate(month: 10, day: 31),
+                eventType: .seasonal
+            ),
+            ACNHEvent(
+                id: "turkey_day",
+                name: "Turkey Day",
+                iconName: "fork.knife",
+                startDate: EventDate(month: 11, day: 26),
+                endDate: nil,
+                eventType: .holiday
+            ),
+            ACNHEvent(
+                id: "toy_day",
+                name: "Toy Day",
+                iconName: "gift.fill",
+                startDate: EventDate(month: 12, day: 24),
+                endDate: nil,
+                eventType: .holiday
+            ),
+
+            // Cherry Blossom Season
+            ACNHEvent(
+                id: "cherry_blossom_season",
+                name: "Cherry Blossom Season",
+                iconName: "camera.macro",
+                startDate: EventDate(month: 4, day: 1),
+                endDate: EventDate(month: 4, day: 10),
+                eventType: .seasonal
+            ),
+
+            // Mushroom Season
+            ACNHEvent(
+                id: "mushroom_season",
+                name: "Mushroom Season",
+                iconName: "leaf.fill",
+                startDate: EventDate(month: 11, day: 1),
+                endDate: EventDate(month: 11, day: 30),
+                eventType: .seasonal
+            ),
+
+            // Maple Leaf Season
+            ACNHEvent(
+                id: "maple_leaf_season",
+                name: "Maple Leaf Season",
+                iconName: "leaf.fill",
+                startDate: EventDate(month: 11, day: 16),
+                endDate: EventDate(month: 11, day: 25),
+                eventType: .seasonal
+            ),
+
+            // Snowflake Season
+            ACNHEvent(
+                id: "snowflake_season",
+                name: "Snowflake Season",
+                iconName: "snowflake",
+                startDate: EventDate(month: 12, day: 11),
+                endDate: EventDate(month: 2, day: 24),
+                eventType: .seasonal
+            )
+        ]
+    }
+
+    static var currentAndUpcomingEvents: [ACNHEvent] {
+        let sortedEvents = allEvents.sorted { event1, event2 in
+            // Ongoing events first
+            if event1.isOngoing && !event2.isOngoing {
+                return true
+            } else if !event1.isOngoing && event2.isOngoing {
+                return false
+            }
+
+            // Then sort by date
+            if event1.startDate.month != event2.startDate.month {
+                return event1.startDate.month < event2.startDate.month
+            }
+            return event1.startDate.day < event2.startDate.day
+        }
+
+        return sortedEvents.filter { $0.isOngoing || $0.isUpcoming }
+    }
+
+    static var eventsForCurrentMonth: [ACNHEvent] {
+        let calendar = Calendar.current
+        let currentMonth = calendar.component(.month, from: Date())
+
+        return allEvents.filter { event in
+            if event.startDate.month == currentMonth {
+                return true
+            }
+            if let endDate = event.endDate {
+                if event.startDate.month <= currentMonth && endDate.month >= currentMonth {
+                    return true
+                }
+                // Year wrap case
+                if event.startDate.month > endDate.month {
+                    return currentMonth >= event.startDate.month || currentMonth <= endDate.month
+                }
+            }
+            return false
+        }.sorted { event1, event2 in
+            if event1.isOngoing && !event2.isOngoing {
+                return true
+            } else if !event1.isOngoing && event2.isOngoing {
+                return false
+            }
+            return event1.startDate.day < event2.startDate.day
+        }
+    }
+}

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Coordinator/DashboardCoordinator.swift
@@ -46,7 +46,8 @@ final class DashboardCoordinator: Coordinator {
             villagersVM: VillagersSectionReactor(coordinator: self),
             progressVM: CollectionProgressSectionReactor(coordinator: self),
             fixeVisitdNPCListVM: NpcsSectionReactor(state: .init(), mode: .fixedVisit, coordinator: self),
-            randomVisitNPCListVM: NpcsSectionReactor(state: .init(), mode: .randomVisit, coordinator: self)
+            randomVisitNPCListVM: NpcsSectionReactor(state: .init(), mode: .randomVisit, coordinator: self),
+            eventCalendarVM: EventCalendarSectionReactor(coordinator: self)
         )
         rootViewController.addChild(viewController)
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewControllers/DashboardViewController.swift
@@ -63,7 +63,8 @@ final class DashboardViewController: UIViewController {
         villagersVM: VillagersSectionReactor,
         progressVM: CollectionProgressSectionReactor,
         fixeVisitdNPCListVM: NpcsSectionReactor,
-        randomVisitNPCListVM: NpcsSectionReactor
+        randomVisitNPCListVM: NpcsSectionReactor,
+        eventCalendarVM: EventCalendarSectionReactor
     ) {
         let userInfoSection = SectionView(
             title: "My Island".localized,
@@ -95,11 +96,17 @@ final class DashboardViewController: UIViewController {
             iconName: "pin.fill",
             contentView: NpcsView(fixeVisitdNPCListVM)
         )
+        let eventCalendarSection = SectionView(
+            title: "Event Calendar".localized,
+            iconName: "calendar",
+            contentView: EventCalendarView(eventCalendarVM)
+        )
         sectionsScrollView.addSection(userInfoSection,
-                                      tasksSection, 
-                                      villagersSection, 
-                                      progressSection, 
-                                      randomVisitResidentsSectionView, 
+                                      tasksSection,
+                                      eventCalendarSection,
+                                      villagersSection,
+                                      progressSection,
+                                      randomVisitResidentsSectionView,
                                       fixedVisitResidentsSectionView)
     }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/EventCalendarSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/EventCalendarSectionReactor.swift
@@ -20,15 +20,12 @@ final class EventCalendarSectionReactor: Reactor {
 
     struct State {
         var events: [ACNHEvent] = []
-        var ongoingEvents: [ACNHEvent] = []
-        var upcomingEvents: [ACNHEvent] = []
     }
 
     let initialState: State
-    private let coordinator: DashboardCoordinator
 
     init(coordinator: DashboardCoordinator) {
-        self.coordinator = coordinator
+        // coordinator is reserved for future use (e.g., event detail navigation)
         self.initialState = State()
     }
 
@@ -45,8 +42,6 @@ final class EventCalendarSectionReactor: Reactor {
         switch mutation {
         case .setEvents(let events):
             newState.events = events
-            newState.ongoingEvents = events.filter { $0.isOngoing }
-            newState.upcomingEvents = events.filter { $0.isUpcoming && !$0.isOngoing }
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/EventCalendarSectionReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/EventCalendarSectionReactor.swift
@@ -1,0 +1,53 @@
+//
+//  EventCalendarSectionReactor.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2024/01/01.
+//
+
+import Foundation
+import ReactorKit
+
+final class EventCalendarSectionReactor: Reactor {
+
+    enum Action {
+        case fetch
+    }
+
+    enum Mutation {
+        case setEvents(_ events: [ACNHEvent])
+    }
+
+    struct State {
+        var events: [ACNHEvent] = []
+        var ongoingEvents: [ACNHEvent] = []
+        var upcomingEvents: [ACNHEvent] = []
+    }
+
+    let initialState: State
+    private let coordinator: DashboardCoordinator
+
+    init(coordinator: DashboardCoordinator) {
+        self.coordinator = coordinator
+        self.initialState = State()
+    }
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .fetch:
+            let events = ACNHEvent.eventsForCurrentMonth
+            return Observable.just(Mutation.setEvents(events))
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setEvents(let events):
+            newState.events = events
+            newState.ongoingEvents = events.filter { $0.isOngoing }
+            newState.upcomingEvents = events.filter { $0.isUpcoming && !$0.isOngoing }
+        }
+        return newState
+    }
+}

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/EventCalendarView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/EventCalendarView.swift
@@ -11,7 +11,12 @@ import RxSwift
 final class EventCalendarView: UIView {
 
     private let disposeBag = DisposeBag()
-    private var heightConstraint: NSLayoutConstraint!
+
+    private lazy var heightConstraint: NSLayoutConstraint = {
+        let constraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 40)
+        constraint.priority = .defaultHigh
+        return constraint
+    }()
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
@@ -34,9 +39,6 @@ final class EventCalendarView: UIView {
     private func configure() {
         addSubviews(stackView, emptyLabel)
 
-        heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 40)
-        heightConstraint.priority = .defaultHigh
-
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -54,6 +56,7 @@ final class EventCalendarView: UIView {
             .disposed(by: disposeBag)
 
         reactor.state.map { $0.events }
+            .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] events in
                 self?.updateUI(with: events)
@@ -91,6 +94,7 @@ final class EventCalendarView: UIView {
         nameLabel.text = event.name.localized
         nameLabel.textColor = event.isOngoing ? .acText : .acSecondaryText
         nameLabel.font = .preferredFont(for: .callout, weight: event.isOngoing ? .semibold : .regular)
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let dateLabel = UILabel()
         dateLabel.text = event.dateDisplayString
@@ -100,7 +104,7 @@ final class EventCalendarView: UIView {
 
         let statusLabel = UILabel()
         if event.isOngoing {
-            statusLabel.text = "Ongoing".localized
+            statusLabel.text = " \("Ongoing".localized) "
             statusLabel.textColor = .acNavigationBarTint
             statusLabel.font = .preferredFont(for: .caption2, weight: .bold)
             statusLabel.backgroundColor = .acNavigationBarTint.withAlphaComponent(0.2)
@@ -146,7 +150,7 @@ extension EventCalendarView {
 
     convenience init(_ reactor: EventCalendarSectionReactor) {
         self.init(frame: .zero)
-        bind(to: reactor)
         configure()
+        bind(to: reactor)
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/EventCalendarView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/EventCalendarView.swift
@@ -1,0 +1,152 @@
+//
+//  EventCalendarView.swift
+//  Animal-Crossing-Wiki
+//
+//  Created by Claude on 2024/01/01.
+//
+
+import UIKit
+import RxSwift
+
+final class EventCalendarView: UIView {
+
+    private let disposeBag = DisposeBag()
+    private var heightConstraint: NSLayoutConstraint!
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    private lazy var emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "No events this month".localized
+        label.textColor = .acSecondaryText
+        label.font = .preferredFont(for: .callout, weight: .regular)
+        label.textAlignment = .center
+        return label
+    }()
+
+    private func configure() {
+        addSubviews(stackView, emptyLabel)
+
+        heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 40)
+        heightConstraint.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            emptyLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            heightConstraint
+        ])
+    }
+
+    func bind(to reactor: EventCalendarSectionReactor) {
+        Observable.just(EventCalendarSectionReactor.Action.fetch)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state.map { $0.events }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] events in
+                self?.updateUI(with: events)
+            }).disposed(by: disposeBag)
+    }
+
+    private func updateUI(with events: [ACNHEvent]) {
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        if events.isEmpty {
+            emptyLabel.isHidden = false
+            stackView.isHidden = true
+        } else {
+            emptyLabel.isHidden = true
+            stackView.isHidden = false
+
+            events.forEach { event in
+                let eventRow = createEventRow(for: event)
+                stackView.addArrangedSubview(eventRow)
+            }
+        }
+    }
+
+    private func createEventRow(for event: ACNHEvent) -> UIView {
+        let containerView = UIView()
+        containerView.backgroundColor = event.isOngoing ? .acHeaderBackground.withAlphaComponent(0.3) : .clear
+        containerView.layer.cornerRadius = 8
+
+        let iconImageView = UIImageView()
+        iconImageView.image = UIImage(systemName: event.iconName)
+        iconImageView.tintColor = event.isOngoing ? .acNavigationBarTint : .acSecondaryText
+        iconImageView.contentMode = .scaleAspectFit
+
+        let nameLabel = UILabel()
+        nameLabel.text = event.name.localized
+        nameLabel.textColor = event.isOngoing ? .acText : .acSecondaryText
+        nameLabel.font = .preferredFont(for: .callout, weight: event.isOngoing ? .semibold : .regular)
+
+        let dateLabel = UILabel()
+        dateLabel.text = event.dateDisplayString
+        dateLabel.textColor = .acSecondaryText
+        dateLabel.font = .preferredFont(for: .caption1, weight: .regular)
+        dateLabel.textAlignment = .right
+
+        let statusLabel = UILabel()
+        if event.isOngoing {
+            statusLabel.text = "Ongoing".localized
+            statusLabel.textColor = .acNavigationBarTint
+            statusLabel.font = .preferredFont(for: .caption2, weight: .bold)
+            statusLabel.backgroundColor = .acNavigationBarTint.withAlphaComponent(0.2)
+            statusLabel.layer.cornerRadius = 4
+            statusLabel.clipsToBounds = true
+            statusLabel.textAlignment = .center
+        }
+        statusLabel.isHidden = !event.isOngoing
+
+        containerView.addSubviews(iconImageView, nameLabel, dateLabel, statusLabel)
+
+        NSLayoutConstraint.activate([
+            containerView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+
+            iconImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 8),
+            iconImageView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
+            nameLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+
+            statusLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 8),
+            statusLabel.centerYAnchor.constraint(equalTo: nameLabel.centerYAnchor),
+            statusLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 50),
+            statusLabel.heightAnchor.constraint(equalToConstant: 18),
+
+            dateLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -8),
+            dateLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            dateLabel.leadingAnchor.constraint(greaterThanOrEqualTo: statusLabel.trailingAnchor, constant: 8)
+        ])
+
+        // Add bottom constraint for name label
+        let bottomConstraint = nameLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8)
+        bottomConstraint.priority = .defaultHigh
+        bottomConstraint.isActive = true
+
+        return containerView
+    }
+}
+
+extension EventCalendarView {
+
+    convenience init(_ reactor: EventCalendarSectionReactor) {
+        self.init(frame: .zero)
+        bind(to: reactor)
+        configure()
+    }
+}


### PR DESCRIPTION
## Summary
- 동물의 숲 연간 이벤트 일정을 보여주는 캘린더 섹션을 대시보드에 추가
- ACNHEvent 모델, EventCalendarSectionReactor, EventCalendarView 구현
- 현재 진행 중인 이벤트 하이라이트 표시 기능 포함

## Changes
- `Models/ACNHEvent.swift`: 이벤트 데이터 모델 (낚시 대회, 곤충 채집 대회, 시즌 이벤트 등 주요 이벤트 데이터 포함)
- `EventCalendarSectionReactor.swift`: ReactorKit 패턴의 ViewModel
- `EventCalendarView.swift`: 이벤트 목록 UI 컴포넌트
- `DashboardViewController.swift`: 이벤트 캘린더 섹션 추가
- `DashboardCoordinator.swift`: EventCalendarSectionReactor 초기화
- `Localizable.strings` (ko/en): 이벤트명 로컬라이징

## Test Plan
- [ ] 대시보드에서 이벤트 캘린더 섹션이 표시되는지 확인
- [ ] 현재 월의 이벤트가 올바르게 표시되는지 확인
- [ ] 진행 중인 이벤트가 하이라이트 스타일로 표시되는지 확인
- [ ] 한국어/영어 언어 전환 시 이벤트명이 올바르게 로컬라이징되는지 확인

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)