### PR TITLE
feat: 색상별 체크 기능 구현 (#67)

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.xcdatamodeld/UserCollectionEntity.xcdatamodel/contents
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.xcdatamodeld/UserCollectionEntity.xcdatamodel/contents
@@ -65,6 +65,7 @@
         <attribute name="vision" optional="YES" attributeType="String"/>
         <attribute name="weather" optional="YES" attributeType="String"/>
         <attribute name="whereHow" optional="YES" attributeType="String"/>
+        <attribute name="checkedVariants" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
         <relationship name="userColletion" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserCollectionEntity" inverseName="critters" inverseEntity="UserCollectionEntity"/>
     </entity>
     <entity name="NPCLikeEntity" representedClassName="NPCLikeEntity" syncable="YES" codeGenerationType="class">

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/CoreDataItemsStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/CoreDataItemsStorage.swift
@@ -50,6 +50,22 @@ final class CoreDataItemsStorage: ItemsStorage {
         }
     }
 
+    func updateVariants(_ item: Item) {
+        coreDataStorage.performBackgroundTask { context in
+            do {
+                let object = try self.coreDataStorage.getUserCollection(context)
+                let items = object.critters?.allObjects as? [ItemEntity] ?? []
+                if let index = items.firstIndex(where: { $0.name == item.name && $0.genuine == item.genuine }) {
+                    let existingItem = items[index]
+                    existingItem.checkedVariants = item.checkedVariants.map { Array($0) } as NSArray?
+                    context.saveContext()
+                }
+            } catch {
+                debugPrint(error)
+            }
+        }
+    }
+
     func updates(_ items: [Item]) {
         coreDataStorage.performBackgroundTask { context in
             do {

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/EntityMapping/ItemEntity+Mapping.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/EntityMapping/ItemEntity+Mapping.swift
@@ -71,6 +71,7 @@ extension ItemEntity {
             "concept": item.concepts?.map { $0.rawValue } ?? [],
             "tag": item.tag.map { [$0] } ?? []
         ] as NSDictionary
+        self.checkedVariants = item.checkedVariants.map { Array($0) } as NSArray?
     }
 
     func toKeyword() -> [Keyword: [String]] {
@@ -141,7 +142,8 @@ extension ItemEntity {
             doorDeco: doorDeco,
             musicURL: musicURL,
             themes: themes as? [String],
-            styles: (styles as? [String])?.compactMap { Style(rawValue: $0) }
+            styles: (styles as? [String])?.compactMap { Style(rawValue: $0) },
+            checkedVariants: (checkedVariants as? [String]).map { Set($0) }
         )
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/ItemsStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/ItemsStorage.swift
@@ -14,4 +14,5 @@ protocol ItemsStorage {
     func update(_ item: Item)
     func updates(_ items: [Item])
     func reset(category: Category)
+    func updateVariants(_ item: Item)
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Extension/String+extension.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Extension/String+extension.swift
@@ -27,7 +27,7 @@ extension String {
     var isChosung: Bool {
         var isChosung = false
         for char in self {
-            if 0 < hangul.filter({ $0.contains(char)}).count {
+            if !hangul.filter({ $0.contains(char)}).isEmpty {
                 isChosung = true
             } else {
                 isChosung = false

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Models/Items/Item.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Models/Items/Item.swift
@@ -72,6 +72,8 @@ struct Item {
     var styles: [Style]?
     
     var soundType: SoundType?
+
+    var checkedVariants: Set<String>?
 }
 
 extension Item {

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewControllers/ItemDetailViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewControllers/ItemDetailViewController.swift
@@ -105,6 +105,24 @@ final class ItemDetailViewController: UIViewController {
             .subscribe(onNext: { [weak self]  image in
                 self?.itemDetailInfoView?.changeImage(image)
             }).disposed(by: disposeBag)
+
+        itemVariantsColorView?.didTapVariantCheck
+            .map { ItemDetailReactor.Action.checkVariant($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        itemVariantsPatternView?.didTapVariantCheck
+            .map { ItemDetailReactor.Action.checkVariant($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state.map { $0.checkedVariants }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] checkedVariants in
+                self?.itemVariantsColorView?.updateCheckedVariants(checkedVariants)
+                self?.itemVariantsPatternView?.updateCheckedVariants(checkedVariants)
+            }).disposed(by: disposeBag)
     }
 
     private func setUpSection(in item: Item) {

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewControllers/ItemsViewController.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewControllers/ItemsViewController.swift
@@ -397,7 +397,7 @@ extension ItemsViewController {
         let allSelectAction = UIAction(
             title: Menu.allSelect.title,
             image: UIImage(systemName: "text.badge.checkmark")
-        ) { [weak self] action in
+        ) { [weak self] _ in
             guard let owner = self else {
                 return
             }
@@ -415,7 +415,7 @@ extension ItemsViewController {
         let resetAction = UIAction(
             title: Menu.reset.title,
             image: UIImage(systemName: "arrow.counterclockwise")
-        ) { [weak self] action in
+        ) { [weak self] _ in
             guard let owner = self else {
                 return
             }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewModels/ItemDetailReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewModels/ItemDetailReactor.swift
@@ -15,6 +15,7 @@ final class ItemDetailReactor: Reactor {
         case check
         case didTapKeyword(_ keyword: String)
         case play
+        case checkVariant(_ variantId: String)
     }
 
     enum Mutation {
@@ -22,11 +23,14 @@ final class ItemDetailReactor: Reactor {
         case updateAcquired
         case showKeywordList(title: String, keyword: Keyword)
         case showMusicPlayer
+        case setCheckedVariants(_ checkedVariants: Set<String>)
+        case toggleVariant(_ variantId: String)
     }
 
     struct State {
-        let item: Item
+        var item: Item
         var isAcquired: Bool = false
+        var checkedVariants: Set<String> = []
     }
 
     let initialState: State
@@ -50,18 +54,30 @@ final class ItemDetailReactor: Reactor {
                     }
                     return items[owner.currentState.item.category]
                 }
-                .compactMap { [weak self] items -> Mutation? in
+                .compactMap { [weak self] items -> (isAcquired: Bool, checkedVariants: Set<String>)? in
                     guard let owner = self else {
                         return nil
                     }
-                    return Mutation.setAcquired(items.contains(owner.currentState.item))
+                    let currentItem = owner.currentState.item
+                    if let storedItem = items.first(where: { $0 == currentItem }) {
+                        return (true, storedItem.checkedVariants ?? [])
+                    }
+                    return (false, [])
+                }
+                .flatMap { result -> Observable<Mutation> in
+                    return Observable.concat([
+                        .just(.setAcquired(result.isAcquired)),
+                        .just(.setCheckedVariants(result.checkedVariants))
+                    ])
                 }
             return collectedState
 
         case .check:
             HapticManager.shared.impact(style: .medium)
-            Items.shared.updateItem(currentState.item)
-            storage.update(currentState.item)
+            var updatedItem = currentState.item
+            updatedItem.checkedVariants = currentState.checkedVariants.isEmpty ? nil : currentState.checkedVariants
+            Items.shared.updateItem(updatedItem)
+            storage.update(updatedItem)
             return .just(.updateAcquired)
 
         case .didTapKeyword(let value):
@@ -77,6 +93,10 @@ final class ItemDetailReactor: Reactor {
 
         case .play:
             return .just(.showMusicPlayer)
+
+        case .checkVariant(let variantId):
+            HapticManager.shared.impact(style: .light)
+            return .just(.toggleVariant(variantId))
         }
     }
 
@@ -110,6 +130,19 @@ final class ItemDetailReactor: Reactor {
                 coordinator?.showMusicPlayer()
             }
             MusicPlayerManager.shared.choice(currentState.item)
+
+        case .setCheckedVariants(let checkedVariants):
+            newState.checkedVariants = checkedVariants
+
+        case .toggleVariant(let variantId):
+            if newState.checkedVariants.contains(variantId) {
+                newState.checkedVariants.remove(variantId)
+            } else {
+                newState.checkedVariants.insert(variantId)
+            }
+            newState.item.checkedVariants = newState.checkedVariants.isEmpty ? nil : newState.checkedVariants
+            storage.updateVariants(newState.item)
+            Items.shared.updateItemVariants(newState.item)
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewModels/ItemsReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/ViewModels/ItemsReactor.swift
@@ -300,7 +300,7 @@ final class ItemsReactor: Reactor {
         }
     }
 
-    private func setUpUserItem() ->  Observable<[Item]> {
+    private func setUpUserItem() -> Observable<[Item]> {
         switch mode {
         case .all:
             return Items.shared.itemList

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/CategoryRow.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/CategoryRow.swift
@@ -30,10 +30,6 @@ final class CategoryRow: UITableViewCell {
         itemCountLabel.text = nil
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-    }
-
     func setUp(iconName: String, title: String, itemCount: Int) {
         iconImage.image = UIImage(named: iconName)
         titleLabel.text = title

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/ItemSeasonView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/ItemSeasonView.swift
@@ -73,7 +73,7 @@ final class ItemSeasonView: UIView {
     }
 
     private func setUpCalendar(months: [Int]) {
-        if backgroundStackView.arrangedSubviews.last as? CalendarView != nil {
+        if backgroundStackView.arrangedSubviews.last is CalendarView {
             backgroundStackView.arrangedSubviews.last?.removeFromSuperview()
         }
         let calendarView = CalendarView(months: months)

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/VariantCell.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Catalog/Views/VariantCell.swift
@@ -6,15 +6,39 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 final class VariantCell: UICollectionViewCell {
 
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
 
+    private(set) var disposeBag = DisposeBag()
+
+    private lazy var checkboxButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        button.setImage(UIImage(systemName: "circle", withConfiguration: config), for: .normal)
+        button.tintColor = .acNavigationBarTint
+        return button
+    }()
+
+    var isVariantChecked: Bool = false {
+        didSet {
+            updateCheckboxAppearance()
+        }
+    }
+
+    var checkboxTapped: ControlEvent<Void> {
+        return checkboxButton.rx.tap
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         titleLabel.font = .preferredFont(for: .footnote, weight: .bold)
+        setUpCheckbox()
     }
 
     override func prepareForReuse() {
@@ -22,10 +46,34 @@ final class VariantCell: UICollectionViewCell {
         imageView.kf.cancelDownloadTask()
         imageView.image = nil
         titleLabel.text = nil
+        isVariantChecked = false
+        disposeBag = DisposeBag()
+    }
+
+    private func setUpCheckbox() {
+        contentView.addSubview(checkboxButton)
+        NSLayoutConstraint.activate([
+            checkboxButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 2),
+            checkboxButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -2),
+            checkboxButton.widthAnchor.constraint(equalToConstant: 24),
+            checkboxButton.heightAnchor.constraint(equalToConstant: 24)
+        ])
+    }
+
+    private func updateCheckboxAppearance() {
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        let imageName = isVariantChecked ? "checkmark.circle.fill" : "circle"
+        checkboxButton.setImage(UIImage(systemName: imageName, withConfiguration: config), for: .normal)
     }
 
     func setUp(imageURL: String, name: String?) {
         imageView.setImage(with: imageURL)
         titleLabel.text = name
+    }
+
+    func setUp(imageURL: String, name: String?, isChecked: Bool) {
+        imageView.setImage(with: imageURL)
+        titleLabel.text = name
+        isVariantChecked = isChecked
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
@@ -410,6 +410,16 @@ extension Items {
         userItems.accept(currentUserItems)
     }
 
+    func updateItemVariants(_ item: Item) {
+        var currentUserItems = userItems.value
+        var items = currentUserItems[item.category] ?? []
+        if let index = items.firstIndex(of: item) {
+            items[index] = item
+            currentUserItems[item.category] = items
+            userItems.accept(currentUserItems)
+        }
+    }
+
     func itemFilter(keyword: String, category: Keyword) -> [Item] {
         let items = allItems.value
         return items


### PR DESCRIPTION
## Summary
- CoreData 스키마에 바리에이션 수집 상태 저장 추가
- ItemDetailViewController에서 색상별 체크 기능 구현
- VariantCell에 체크박스 UI 추가
- 수집 상태 실시간 업데이트 및 iCloud 동기화

## Test plan
- [ ] 아이템 상세 화면에서 바리에이션 체크 가능 확인
- [ ] 체크 상태가 iCloud에 동기화되는지 확인
- [ ] 앱 재실행 후에도 체크 상태가 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)