### PR TITLE
🐛 [fix] validate-architecture.sh Coordinator 오탐지 수정

### DIFF
--- a/scripts/validate-architecture.sh
+++ b/scripts/validate-architecture.sh
@@ -338,7 +338,7 @@ scan_for_violations() {
 # Pattern: match ViewController not preceded by "UI", plus Coordinator, Reactor (not ReactorKit/Reactive)
 COREDATA_DIR="${SOURCES_DIR}/CoreDataStorage"
 scan_for_violations "${COREDATA_DIR}" \
-    '([^I]ViewController[^+]|[^/]Coordinator|[^a-z]Reactor[^Kit+]|APIRequest|APIProvider|DefaultAPIProvider)' \
+    '([^I]ViewController[^+]|[^/a-z]Coordinator|[^a-z]Reactor[^Kit+]|APIRequest|APIProvider|DefaultAPIProvider)' \
     "CoreDataStorage must not reference Presentation or Networking types"
 
 # --- Extension must not reference Presentation or CoreDataStorage ---


### PR DESCRIPTION
## Summary
- Check 4 regex에서 `persistentStoreCoordinator`를 `Coordinator`로 오탐지하는 문제 수정
- 패턴 `[^/]Coordinator` → `[^/a-z]Coordinator`로 변경하여 camelCase 프로퍼티 제외

## Test plan
- [x] `make validate` PASS 확인 (에러 0, 경고 17 allowlisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal architecture validation script to improve pattern matching accuracy and reduce false positives in coordinator naming validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->