### PR TITLE
🐛 [fix] CloudKit 동기화 데이터 유실 방지 강화

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -67,6 +67,11 @@ Find the villagers you have visited and tap the home icon on the villager's page
 "Recovery Complete" = "Recovery Complete";
 "Please restart the app to complete data recovery from iCloud." = "Please restart the app to complete data recovery from iCloud.";
 "Recovery Failed" = "Recovery Failed";
+"iCloud sync status" = "iCloud sync status";
+"Syncing..." = "Syncing...";
+"Local records: %d" = "Local records: %d";
+"Waiting for iCloud data..." = "Waiting for iCloud data...";
+"Last sync: %@" = "Last sync: %@";
 "Notice" = "Notice";
 "Are you sure you want to reset it?" = "Are you sure you want to reset it";
 "Fetching collection data from iCloud..." = "Fetching collection data from iCloud...";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/en.lproj/Localizable.strings
@@ -67,11 +67,11 @@ Find the villagers you have visited and tap the home icon on the villager's page
 "Recovery Complete" = "Recovery Complete";
 "Please restart the app to complete data recovery from iCloud." = "Please restart the app to complete data recovery from iCloud.";
 "Recovery Failed" = "Recovery Failed";
-"iCloud sync status" = "iCloud sync status";
+"iCloud sync status" = "iCloud sync";
 "Syncing..." = "Syncing...";
-"Local records: %d" = "Local records: %d";
 "Waiting for iCloud data..." = "Waiting for iCloud data...";
-"Last sync: %@" = "Last sync: %@";
+"Synced %@ · %d items" = "Synced %@ · %d items";
+"Saved %d items" = "Saved %d items";
 "Notice" = "Notice";
 "Are you sure you want to reset it?" = "Are you sure you want to reset it";
 "Fetching collection data from iCloud..." = "Fetching collection data from iCloud...";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -69,6 +69,11 @@
 "Recovery Complete" = "복구 완료";
 "Please restart the app to complete data recovery from iCloud." = "iCloud에서 데이터 복구를 완료하려면 앱을 다시 시작해 주세요.";
 "Recovery Failed" = "복구 실패";
+"iCloud sync status" = "iCloud 동기화 상태";
+"Syncing..." = "동기화 중...";
+"Local records: %d" = "로컬 레코드: %d개";
+"Waiting for iCloud data..." = "iCloud 데이터 대기 중...";
+"Last sync: %@" = "마지막 동기화: %@";
 "Notice" = "알림";
 "Are you sure you want to reset it?" = "정말 초기화하시겠습니까?\n(되돌릴 수 없습니다.)";
 "Fetching collection data from iCloud..." = "iCloud를 통해 수집 기록을 불러오는 중입니다.";

--- a/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
+++ b/Animal-Crossing-Wiki/Projects/App/Resources/ko.lproj/Localizable.strings
@@ -69,11 +69,11 @@
 "Recovery Complete" = "복구 완료";
 "Please restart the app to complete data recovery from iCloud." = "iCloud에서 데이터 복구를 완료하려면 앱을 다시 시작해 주세요.";
 "Recovery Failed" = "복구 실패";
-"iCloud sync status" = "iCloud 동기화 상태";
+"iCloud sync status" = "iCloud 동기화";
 "Syncing..." = "동기화 중...";
-"Local records: %d" = "로컬 레코드: %d개";
 "Waiting for iCloud data..." = "iCloud 데이터 대기 중...";
-"Last sync: %@" = "마지막 동기화: %@";
+"Synced %@ · %d items" = "%@ 동기화 · %d개 저장됨";
+"Saved %d items" = "%d개 저장됨";
 "Notice" = "알림";
 "Are you sure you want to reset it?" = "정말 초기화하시겠습니까?\n(되돌릴 수 없습니다.)";
 "Fetching collection data from iCloud..." = "iCloud를 통해 수집 기록을 불러오는 중입니다.";

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
@@ -91,11 +91,18 @@ final class CoreDataStorage {
 
     private static let hasEverHadUserCollectionKey = "CoreDataStorage_hasEverHadUserCollection"
 
-    /// 한 번이라도 UserCollectionEntity가 존재했는지 여부 (UserDefaults 기반)
+    /// 한 번이라도 UserCollectionEntity가 존재했는지 여부 (UserDefaults 기반, 메모리 캐싱)
     /// 이 플래그가 true인데 UC가 0개면, 빈 UC 자동 생성 대신 .notFound를 throw
+    private var _hasEverHadUserCollectionCached = UserDefaults.standard.bool(
+        forKey: CoreDataStorage.hasEverHadUserCollectionKey
+    )
     private(set) var hasEverHadUserCollection: Bool {
-        get { UserDefaults.standard.bool(forKey: Self.hasEverHadUserCollectionKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Self.hasEverHadUserCollectionKey) }
+        get { _hasEverHadUserCollectionCached }
+        set {
+            guard _hasEverHadUserCollectionCached != newValue else { return }
+            _hasEverHadUserCollectionCached = newValue
+            UserDefaults.standard.set(newValue, forKey: Self.hasEverHadUserCollectionKey)
+        }
     }
 
     /// 의도적 데이터 초기화 시 호출 — 새 UC 생성을 다시 허용
@@ -104,19 +111,21 @@ final class CoreDataStorage {
         os_log(.info, log: .default, "🛡️ hasEverHadUserCollection cleared (intentional reset)")
     }
 
+    /// 첫 Import 완료 후 UC 생성/기본 데이터 생성을 유예하는 시간 (초)
+    private static let gracePeriodSeconds: TimeInterval = 120
+
+    /// 첫 Import 완료 후 grace period 내인지 확인
+    private var isWithinGracePeriod: Bool {
+        guard let firstImportDate = _firstImportCompletedAt.withLock({ $0 }) else { return false }
+        return Date().timeIntervalSince(firstImportDate) < Self.gracePeriodSeconds
+    }
+
     /// Import 또는 sync reset 진행 중이거나, grace period 내인지 확인
     /// DailyTask 등 외부 Storage에서도 기본값 생성 억제 판단에 사용
     /// 주의: hasEverHadUserCollection은 여기에 포함하지 않음 — 그 플래그는 getUserCollection()에서만 사용
     ///       여기에 포함하면 기존 유저의 DailyTask 자동 생성이 영구적으로 차단됨
     var shouldSuppressDataCreation: Bool {
-        if isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress {
-            return true
-        }
-        if let firstImportDate = _firstImportCompletedAt.withLock({ $0 }),
-           Date().timeIntervalSince(firstImportDate) < 120 {
-            return true
-        }
-        return false
+        isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress || isWithinGracePeriod
     }
 
     // MARK: - Private API Notification Names (fragile)
@@ -486,6 +495,24 @@ final class CoreDataStorage {
 
 extension CoreDataStorage {
 
+    // MARK: - Entity Count Helper
+
+    private static let entityNames = [
+        "UserCollectionEntity", "ItemEntity", "DailyTaskEntity",
+        "VillagersLikeEntity", "VillagersHouseEntity", "NPCLikeEntity",
+        "VariantCollectionEntity"
+    ]
+
+    /// 모든 엔티티의 레코드 수를 한 번에 조회 (logSyncDiagnostics, fetchSyncStatus 공용)
+    private func entityCounts(in context: NSManagedObjectContext) -> [String: Int] {
+        var counts: [String: Int] = [:]
+        for name in Self.entityNames {
+            let request = NSFetchRequest<NSManagedObject>(entityName: name)
+            counts[name] = (try? context.count(for: request)) ?? -1
+        }
+        return counts
+    }
+
     /// CloudKit Import/Export 이벤트 후 데이터 상태를 로깅 (5초 throttle)
     func logSyncDiagnostics(phase: String) {
         let shouldProceed = lastDiagnosticsDate.withLock { lastDate -> Bool in
@@ -506,17 +533,7 @@ extension CoreDataStorage {
         persistentContainer.performBackgroundTask { context in
             context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
 
-            let entityNames = [
-                "UserCollectionEntity", "ItemEntity", "DailyTaskEntity",
-                "VillagersLikeEntity", "VillagersHouseEntity", "NPCLikeEntity",
-                "VariantCollectionEntity"
-            ]
-
-            var counts: [String: Int] = [:]
-            for name in entityNames {
-                let request = NSFetchRequest<NSManagedObject>(entityName: name)
-                counts[name] = (try? context.count(for: request)) ?? -1
-            }
+            let counts = self.entityCounts(in: context)
 
             os_log(.info, log: .default,
                    "📊 [%{public}@] UC=%d Items=%d Tasks=%d VLike=%d VHouse=%d NPC=%d Variants=%d",
@@ -560,16 +577,14 @@ extension CoreDataStorage {
         persistentContainer.performBackgroundTask { context in
             context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
 
-            let ucCount = (try? context.count(for: UserCollectionEntity.fetchRequest())) ?? 0
-            let itemCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "ItemEntity"))) ?? 0
-            let taskCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "DailyTaskEntity"))) ?? 0
-            let vLikeCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "VillagersLikeEntity"))) ?? 0
-            let vHouseCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "VillagersHouseEntity"))) ?? 0
-
-            let totalRecords = itemCount + taskCount + vLikeCount + vHouseCount
+            let counts = self.entityCounts(in: context)
+            let totalRecords = (counts["ItemEntity"] ?? 0)
+                + (counts["DailyTaskEntity"] ?? 0)
+                + (counts["VillagersLikeEntity"] ?? 0)
+                + (counts["VillagersHouseEntity"] ?? 0)
 
             let info = SyncStatusInfo(
-                hasUserCollection: ucCount > 0,
+                hasUserCollection: (counts["UserCollectionEntity"] ?? 0) > 0,
                 totalRecordCount: totalRecords,
                 lastImportDate: self.lastSuccessfulImportDate,
                 lastExportDate: self.lastSuccessfulExportDate,
@@ -828,9 +843,8 @@ extension CoreDataStorage {
             throw CoreDataStorageError.notFound
         }
 
-        if let firstImportDate = _firstImportCompletedAt.withLock({ $0 }),
-           Date().timeIntervalSince(firstImportDate) < 120 {
-            os_log(.info, log: .default, "⏳ getUserCollection: No UC found, within grace period (120s) — skipping creation")
+        if isWithinGracePeriod {
+            os_log(.info, log: .default, "⏳ getUserCollection: No UC found, within grace period (%.0fs) — skipping creation", Self.gracePeriodSeconds)
             throw CoreDataStorageError.notFound
         }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
@@ -73,6 +73,52 @@ final class CoreDataStorage {
     /// Consolidation 5초 지연 타이머 — 새 import 시 이전 타이머 취소용
     private var consolidationWorkItem: DispatchWorkItem?
 
+    /// 마지막 CloudKit Import 성공 시각 — 동기화 상태 표시에 사용
+    private let _lastSuccessfulImportDate = OSAllocatedUnfairLock<Date?>(initialState: nil)
+    var lastSuccessfulImportDate: Date? {
+        get { _lastSuccessfulImportDate.withLock { $0 } }
+        set { _lastSuccessfulImportDate.withLock { $0 = newValue } }
+    }
+
+    /// 마지막 CloudKit Export 성공 시각 — 동기화 상태 표시에 사용
+    private let _lastSuccessfulExportDate = OSAllocatedUnfairLock<Date?>(initialState: nil)
+    var lastSuccessfulExportDate: Date? {
+        get { _lastSuccessfulExportDate.withLock { $0 } }
+        set { _lastSuccessfulExportDate.withLock { $0 = newValue } }
+    }
+
+    // MARK: - Known User Flag
+
+    private static let hasEverHadUserCollectionKey = "CoreDataStorage_hasEverHadUserCollection"
+
+    /// 한 번이라도 UserCollectionEntity가 존재했는지 여부 (UserDefaults 기반)
+    /// 이 플래그가 true인데 UC가 0개면, 빈 UC 자동 생성 대신 .notFound를 throw
+    private(set) var hasEverHadUserCollection: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.hasEverHadUserCollectionKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.hasEverHadUserCollectionKey) }
+    }
+
+    /// 의도적 데이터 초기화 시 호출 — 새 UC 생성을 다시 허용
+    func clearHasEverHadUserCollection() {
+        hasEverHadUserCollection = false
+        os_log(.info, log: .default, "🛡️ hasEverHadUserCollection cleared (intentional reset)")
+    }
+
+    /// Import 또는 sync reset 진행 중이거나, grace period 내인지 확인
+    /// DailyTask 등 외부 Storage에서도 기본값 생성 억제 판단에 사용
+    /// 주의: hasEverHadUserCollection은 여기에 포함하지 않음 — 그 플래그는 getUserCollection()에서만 사용
+    ///       여기에 포함하면 기존 유저의 DailyTask 자동 생성이 영구적으로 차단됨
+    var shouldSuppressDataCreation: Bool {
+        if isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress {
+            return true
+        }
+        if let firstImportDate = _firstImportCompletedAt.withLock({ $0 }),
+           Date().timeIntervalSince(firstImportDate) < 120 {
+            return true
+        }
+        return false
+    }
+
     // MARK: - Private API Notification Names (fragile)
     // These notification names are undocumented and may change without notice.
     // Verified working on iOS 16–18. Remove if Apple provides a public API.
@@ -298,6 +344,12 @@ final class CoreDataStorage {
                 postSyncFailureIfNeeded(error)
             } else {
                 os_log(.info, log: .default, "CloudKit %{public}@ succeeded", type)
+                // 동기화 성공 시각 기록 (설정 화면 표시용)
+                if event.type == .import {
+                    lastSuccessfulImportDate = Date()
+                } else if event.type == .export {
+                    lastSuccessfulExportDate = Date()
+                }
             }
             if event.type == .import {
                 isImportInProgress = false
@@ -501,6 +553,46 @@ extension CoreDataStorage {
                 os_log(.info, log: .default, "📊 [%{public}@] UC[%d] id=%{public}@ name=%{private}@ island=%{private}@ | items=%d tasks=%d vLike=%d vHouse=%d npc=%d variants=%d", phase, index, objectID, uc.name ?? "(nil)", uc.islandName ?? "(nil)", critters, tasks, vLike, vHouse, npcLike, variants)
             }
         }
+    }
+
+    /// 설정 화면에 표시할 동기화 상태 정보를 조회
+    func fetchSyncStatus(completion: @escaping (SyncStatusInfo) -> Void) {
+        persistentContainer.performBackgroundTask { context in
+            context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+            let ucCount = (try? context.count(for: UserCollectionEntity.fetchRequest())) ?? 0
+            let itemCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "ItemEntity"))) ?? 0
+            let taskCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "DailyTaskEntity"))) ?? 0
+            let vLikeCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "VillagersLikeEntity"))) ?? 0
+            let vHouseCount = (try? context.count(for: NSFetchRequest<NSManagedObject>(entityName: "VillagersHouseEntity"))) ?? 0
+
+            let totalRecords = itemCount + taskCount + vLikeCount + vHouseCount
+
+            let info = SyncStatusInfo(
+                hasUserCollection: ucCount > 0,
+                totalRecordCount: totalRecords,
+                lastImportDate: self.lastSuccessfulImportDate,
+                lastExportDate: self.lastSuccessfulExportDate,
+                isSyncing: self.isImportInProgress || self.isSyncResetInProgress
+            )
+
+            DispatchQueue.main.async {
+                completion(info)
+            }
+        }
+    }
+}
+
+/// 동기화 상태 정보 모델
+struct SyncStatusInfo {
+    let hasUserCollection: Bool
+    let totalRecordCount: Int
+    let lastImportDate: Date?
+    let lastExportDate: Date?
+    let isSyncing: Bool
+
+    var lastSyncDate: Date? {
+        [lastImportDate, lastExportDate].compactMap { $0 }.max()
     }
 }
 
@@ -716,6 +808,10 @@ extension CoreDataStorage {
         }
 
         if let existing = sorted.first {
+            // UC가 존재하면 "기존 유저" 플래그를 기록
+            if !hasEverHadUserCollection {
+                hasEverHadUserCollection = true
+            }
             return existing
         }
 
@@ -723,7 +819,8 @@ extension CoreDataStorage {
         // 1. Import 대기 중 (신규 설치 시 CloudKit Import 완료 전)
         // 2. Import 진행 중 (timeout 후에도 import가 아직 끝나지 않은 경우)
         // 3. Sync reset 진행 중 (Change Token Expired 후 re-import 대기)
-        // 4. 첫 Import 완료 후 30초 유예 (relationship 해소 시간 확보)
+        // 4. 첫 Import 완료 후 120초 유예 (relationship 해소 시간 확보)
+        // 5. 기존 유저 — 이전에 UC가 존재했으므로, CloudKit re-import 대기 필요
         if isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress {
             os_log(.info, log: .default,
                    "⏳ getUserCollection: No UC found — skipping creation (waiting=%{public}@, importing=%{public}@, reset=%{public}@)",
@@ -732,12 +829,20 @@ extension CoreDataStorage {
         }
 
         if let firstImportDate = _firstImportCompletedAt.withLock({ $0 }),
-           Date().timeIntervalSince(firstImportDate) < 30 {
-            os_log(.info, log: .default, "⏳ getUserCollection: No UC found, within grace period — skipping creation")
+           Date().timeIntervalSince(firstImportDate) < 120 {
+            os_log(.info, log: .default, "⏳ getUserCollection: No UC found, within grace period (120s) — skipping creation")
             throw CoreDataStorageError.notFound
         }
 
-        os_log(.info, log: .default, "⚠️ getUserCollection: No UC found — creating new one")
+        // 기존 유저인데 UC가 0개 → CloudKit 미러 재구성 또는 re-import 대기 상태
+        // 빈 UC를 생성하면 CloudKit에 빈 데이터가 Export되어 기존 데이터를 오염시킬 수 있음
+        if hasEverHadUserCollection {
+            os_log(.error, log: .default,
+                   "🛡️ getUserCollection: No UC found but hasEverHadUserCollection=true — blocking empty UC creation to protect cloud data")
+            throw CoreDataStorageError.notFound
+        }
+
+        os_log(.info, log: .default, "⚠️ getUserCollection: No UC found (fresh user) — creating new one")
         return UserCollectionEntity(UserInfo(), context: context)
     }
 
@@ -814,6 +919,9 @@ extension CoreDataStorage {
 
                 // migration flag 유지 — 재시작 시 re-export 중복 방지
                 UserDefaults.standard.set(true, forKey: "didMigrateExistingDataToCloudKit_v2")
+
+                // 기존 유저 플래그 유지 — 재시작 후 CloudKit re-import 전까지 빈 UC 생성 방지
+                // (복구 = 기존 유저이므로 true 유지가 올바름)
 
                 os_log(.info, log: .default, "🔄 Recovery: store files deleted — app restart required for CloudKit re-import")
                 completion(.success(()))

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/DailyTaskStorage/CoreDataDailyTaskStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/DailyTaskStorage/CoreDataDailyTaskStorage.swift
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 import CoreData
+import os
 
 final class CoreDataDailyTaskStorage: DailyTaskStorage {
 
@@ -23,9 +24,11 @@ final class CoreDataDailyTaskStorage: DailyTaskStorage {
                 do {
                     let object = try self.coreDataStorage.getUserCollection(context)
                     var itemEntities = object.dailyTasks?.allObjects as? [DailyTaskEntity] ?? []
-                    // Import 진행 중에는 기본 태스크 자동 생성을 건너뜀
-                    // — CloudKit에서 태스크가 아직 도착하지 않았을 수 있음
-                    if itemEntities.isEmpty && !CoreDataStorage.shared.isImportInProgress {
+                    // 기본 태스크 자동 생성은 아래 조건을 모두 만족할 때만 수행:
+                    // - 태스크가 0개
+                    // - Import/sync reset/grace period가 아님
+                    // - 이전에 UC가 존재한 적 없음 (기존 유저면 CloudKit 데이터를 기다려야 함)
+                    if itemEntities.isEmpty && !self.coreDataStorage.shouldSuppressDataCreation {
                         itemEntities = DailyTask.tasks.map { DailyTaskEntity($0, context: context)}
                         object.addToDailyTasks(NSSet(array: itemEntities))
                         context.saveContext()
@@ -75,7 +78,7 @@ final class CoreDataDailyTaskStorage: DailyTaskStorage {
                 }
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "DailyTaskStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
@@ -92,7 +95,7 @@ final class CoreDataDailyTaskStorage: DailyTaskStorage {
                 }
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "DailyTaskStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/CoreDataItemsStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/ItemsStorage/CoreDataItemsStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import os
 
 final class CoreDataItemsStorage: ItemsStorage {
 
@@ -46,7 +47,7 @@ final class CoreDataItemsStorage: ItemsStorage {
 
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "ItemsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
@@ -59,7 +60,7 @@ final class CoreDataItemsStorage: ItemsStorage {
                 object.addToCritters(NSSet(array: newItems))
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "ItemsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
@@ -72,7 +73,7 @@ final class CoreDataItemsStorage: ItemsStorage {
                 object.removeFromCritters(NSSet(array: items.filter { $0.category == category.rawValue }))
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "ItemsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/UserInfoStorage/CoreDataUserInfoStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/UserInfoStorage/CoreDataUserInfoStorage.swift
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 import CoreData
+import os
 
 final class CoreDataUserInfoStorage: UserInfoStorage {
 
@@ -38,16 +39,19 @@ final class CoreDataUserInfoStorage: UserInfoStorage {
                 object.islandReputation = Int16(userInfo.islandReputation)
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "UserInfoStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
 
     func resetUserInfo() {
         coreDataStorage.performBackgroundTask { [weak self] context in
-            let object = try? self?.coreDataStorage.getUserCollection(context) as? NSManagedObject
+            guard let self else { return }
+            let object = try? self.coreDataStorage.getUserCollection(context) as? NSManagedObject
             object.flatMap { context.delete($0) }
             context.saveContext()
+            // 의도적 초기화이므로 기존 유저 플래그를 리셋하여 새 UC 생성을 허용
+            self.coreDataStorage.clearHasEverHadUserCollection()
         }
     }
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VariantsStorage/CoreDataVariantsStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VariantsStorage/CoreDataVariantsStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import os
 
 final class CoreDataVariantsStorage: VariantsStorage {
 
@@ -89,7 +90,7 @@ final class CoreDataVariantsStorage: VariantsStorage {
 
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "VariantsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
@@ -106,7 +107,7 @@ final class CoreDataVariantsStorage: VariantsStorage {
                     context.saveContext()
                 }
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "VariantsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }
@@ -125,7 +126,7 @@ final class CoreDataVariantsStorage: VariantsStorage {
 
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "VariantsStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersHouseStorage/CoreDataVillagersHouseStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersHouseStorage/CoreDataVillagersHouseStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import os
 
 final class CoreDataVillagersHouseStorage: VillagersHouseStorage {
 
@@ -40,7 +41,7 @@ final class CoreDataVillagersHouseStorage: VillagersHouseStorage {
                 }
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "VillagersHouseStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersLikeStorage/CoreDataNPCLikeStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersLikeStorage/CoreDataNPCLikeStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import os
 
 final class CoreDataNPCLikeStorage: NPCLikeStorage {
 
@@ -54,7 +55,7 @@ final class CoreDataNPCLikeStorage: NPCLikeStorage {
                 }
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "NPCLikeStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersLikeStorage/CoreDataVillagersLikeStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/VillagersLikeStorage/CoreDataVillagersLikeStorage.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import os
 
 final class CoreDataVillagersLikeStorage: VillagersLikeStorage {
 
@@ -40,7 +41,7 @@ final class CoreDataVillagersLikeStorage: VillagersLikeStorage {
                 }
                 context.saveContext()
             } catch {
-                debugPrint(error)
+                os_log(.error, log: .default, "VillagersLikeStorage error: %{public}@", error.localizedDescription)
             }
         }
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Extension/DateFormatters.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Extension/DateFormatters.swift
@@ -26,4 +26,13 @@ enum DateFormatters {
         formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
         return formatter
     }()
+
+    // MARK: - Sync Status
+
+    /// 동기화 상태 표시용 상대 시간 포맷터 (예: "3 min. ago")
+    static let syncRelativeDate: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter
+    }()
 }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/AppSettingReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/AppSettingReactor.swift
@@ -14,17 +14,20 @@ final class AppSettingReactor: Reactor {
         case toggleSwitch
         case reset
         case recoverFromCloud // TEMPORARY: Recovery
+        case loadSyncStatus
     }
 
     enum Mutation {
         case setHapticState(_ isOn: Bool)
         case reset(_ isReset: Bool)
         case setRecoveryInProgress(Bool) // TEMPORARY: Recovery
+        case setSyncStatus(SyncStatusInfo)
     }
 
     struct State {
         var currentHapticState: Bool = HapticManager.shared.mode == .on
         var isRecoveryInProgress: Bool = false // TEMPORARY: Recovery
+        var syncStatus: SyncStatusInfo?
     }
 
     let initialState: State
@@ -49,6 +52,15 @@ final class AppSettingReactor: Reactor {
                 .showAlert(title: "Notice".localized, message: "Are you sure you want to reset it?".localized)
                 .map { AppSettingReactor.Mutation.reset($0) }
                 .observe(on: MainScheduler.asyncInstance)
+
+        case .loadSyncStatus:
+            return Observable.create { observer in
+                CoreDataStorage.shared.fetchSyncStatus { info in
+                    observer.onNext(.setSyncStatus(info))
+                    observer.onCompleted()
+                }
+                return Disposables.create()
+            }
 
         // TEMPORARY: Recovery
         case .recoverFromCloud:
@@ -101,6 +113,9 @@ final class AppSettingReactor: Reactor {
         // TEMPORARY: Recovery
         case .setRecoveryInProgress(let inProgress):
             newState.isRecoveryInProgress = inProgress
+
+        case .setSyncStatus(let info):
+            newState.syncStatus = info
         }
         return newState
     }

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/TasksEditReactor.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/ViewModels/TasksEditReactor.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ReactorKit
+import os
 
 final class TasksEditReactor: Reactor {
 
@@ -83,7 +84,7 @@ final class TasksEditReactor: Reactor {
                 .subscribe(onSuccess: { task in
                     Items.shared.deleteTask(task)
                 }, onFailure: { error in
-                    debugPrint(error)
+                    os_log(.error, log: .default, "TasksEditReactor delete error: %{public}@", error.localizedDescription)
                 }).disposed(by: disposeBag)
         }
         return newState

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
@@ -126,9 +126,7 @@ final class AppSettingView: UIView {
         }
 
         if let lastSync = info.lastSyncDate {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .short
-            let relative = formatter.localizedString(for: lastSync, relativeTo: Date())
+            let relative = DateFormatters.syncRelativeDate.localizedString(for: lastSync, relativeTo: Date())
             syncStatusLabel.text = String(
                 format: "Synced %@ · %d items".localized, relative, info.totalRecordCount
             )

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
@@ -19,7 +19,8 @@ final class AppSettingView: UIView {
         let label = UILabel()
         label.font = .preferredFont(for: .caption1, weight: .regular)
         label.textColor = .secondaryLabel
-        label.numberOfLines = 0
+        label.numberOfLines = 1
+        label.textAlignment = .right
         label.text = " "
         return label
     }()
@@ -114,30 +115,28 @@ final class AppSettingView: UIView {
     }
 
     private func updateSyncStatusLabel(_ info: SyncStatusInfo) {
-        var lines: [String] = []
-
         if info.isSyncing {
-            lines.append("Syncing...".localized)
+            syncStatusLabel.text = "Syncing...".localized
+            return
         }
 
-        if info.hasUserCollection {
-            lines.append(
-                String(format: "Local records: %d".localized, info.totalRecordCount)
-            )
-        } else {
-            lines.append("Waiting for iCloud data...".localized)
+        if !info.hasUserCollection {
+            syncStatusLabel.text = "Waiting for iCloud data...".localized
+            return
         }
 
         if let lastSync = info.lastSyncDate {
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .short
             let relative = formatter.localizedString(for: lastSync, relativeTo: Date())
-            lines.append(
-                String(format: "Last sync: %@".localized, relative)
+            syncStatusLabel.text = String(
+                format: "Synced %@ · %d items".localized, relative, info.totalRecordCount
+            )
+        } else {
+            syncStatusLabel.text = String(
+                format: "Saved %d items".localized, info.totalRecordCount
             )
         }
-
-        syncStatusLabel.text = lines.joined(separator: "\n")
     }
 }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
@@ -15,6 +15,15 @@ final class AppSettingView: UIView {
     private let recoverTapGesture = UITapGestureRecognizer() // TEMPORARY: Recovery
     private lazy var recoveryIndicator = UIActivityIndicatorView(style: .medium) // TEMPORARY: Recovery
 
+    private lazy var syncStatusLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(for: .caption1, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.text = " "
+        return label
+    }()
+
     private lazy var backgroundStackView: UIStackView = {
         let stackView = UIStackView(
             axis: .vertical,
@@ -49,6 +58,7 @@ final class AppSettingView: UIView {
         )
         backgroundStackView.addArrangedSubviews(
             InfoContentView(title: "System haptic".localized, contentView: hapticSwitch),
+            InfoContentView(title: "iCloud sync status".localized, contentView: syncStatusLabel),
             recoverView,
             resetView
         )
@@ -90,6 +100,44 @@ final class AppSettingView: UIView {
                 }
             })
             .disposed(by: disposeBag)
+
+        // Sync status display
+        reactor.state.compactMap { $0.syncStatus }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] info in
+                self?.updateSyncStatusLabel(info)
+            })
+            .disposed(by: disposeBag)
+
+        // Load sync status on appear
+        reactor.action.onNext(.loadSyncStatus)
+    }
+
+    private func updateSyncStatusLabel(_ info: SyncStatusInfo) {
+        var lines: [String] = []
+
+        if info.isSyncing {
+            lines.append("Syncing...".localized)
+        }
+
+        if info.hasUserCollection {
+            lines.append(
+                String(format: "Local records: %d".localized, info.totalRecordCount)
+            )
+        } else {
+            lines.append("Waiting for iCloud data...".localized)
+        }
+
+        if let lastSync = info.lastSyncDate {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .short
+            let relative = formatter.localizedString(for: lastSync, relativeTo: Date())
+            lines.append(
+                String(format: "Last sync: %@".localized, relative)
+            )
+        }
+
+        syncStatusLabel.text = lines.joined(separator: "\n")
     }
 }
 

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Presentation/Dashboard/Views/AppSettingView.swift
@@ -30,7 +30,7 @@ final class AppSettingView: UIView {
             axis: .vertical,
             alignment: .fill,
             distribution: .fill,
-            spacing: 4
+            spacing: 16
         )
         return stackView
     }()

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Items.swift
@@ -86,7 +86,7 @@ final class Items {
             .subscribe(onSuccess: { tasks in
                 self.currentDailyTasks.accept(tasks)
             }, onFailure: { error in
-                debugPrint(error)
+                os_log(.error, log: .default, "Items.swift fetch error: %{public}@", error.localizedDescription)
             }).disposed(by: disposeBag)
 
         self.villagersLike.accept(CoreDataVillagersLikeStorage().fetch())
@@ -107,14 +107,14 @@ final class Items {
                 }
                 self.userItems.accept(userItems)
             }, onFailure: { error in
-                debugPrint(error)
+                os_log(.error, log: .default, "Items.swift fetch error: %{public}@", error.localizedDescription)
             }).disposed(by: disposeBag)
 
         CoreDataVariantsStorage().fetchAll()
             .subscribe(onSuccess: { variantsByItem in
                 self.collectedVariants.accept(variantsByItem)
             }, onFailure: { error in
-                debugPrint(error)
+                os_log(.error, log: .default, "Items.swift fetch error: %{public}@", error.localizedDescription)
             }).disposed(by: disposeBag)
     }
 

--- a/docs/features/icloud-sync.md
+++ b/docs/features/icloud-sync.md
@@ -27,7 +27,7 @@ Device A                    CloudKit Server               Device B
 
 | File | 역할 |
 |------|------|
-| `CoreDataStorage.swift` | `NSPersistentCloudKitContainer` 설정, CloudKit 이벤트 감지, iCloud 계정 확인, UC 중복 방지, Persistent History 정리 |
+| `CoreDataStorage.swift` | `NSPersistentCloudKitContainer` 설정, CloudKit 이벤트 감지, iCloud 계정 확인, UC 중복 방지, 기존 유저 보호, 동기화 상태 조회, Persistent History 정리 |
 | `SceneDelegate.swift` | 신규 설치 감지 + CloudKit Import 대기, iCloud 계정/에러 알림, ToastManager 연동 |
 | `Items.swift` | `didReceiveRemoteChanges` 구독 (debounce 2s) → `setUpUserCollection()` |
 | `ToastManager.swift` | 전용 UIWindow 기반 토스트 매니저. 레퍼런스 카운팅, 타임아웃, 백그라운드 dismiss |
@@ -154,17 +154,33 @@ waitForCloudKitImport(timeout: 10)
 
 **문제**: 신규 설치 시 로컬 UC 생성 → CloudKit Import로 기존 UC 도착 → UC 2개 존재 (영구 중복)
 
-**해결**: 다중 억제 플래그
+**해결**: 다중 억제 플래그 + 기존 유저 보호
 
-`getUserCollection()`에서 UC가 없을 때 새 UC 생성을 억제하는 4가지 조건:
+`getUserCollection()`에서 UC가 없을 때 새 UC 생성을 억제하는 5가지 조건:
 
 1. `isWaitingForFirstImport` — 신규 설치 시 Import 완료 전
 2. `isImportInProgress` — Import가 진행 중 (timeout 후에도 import가 끝나지 않은 경우)
 3. `isSyncResetInProgress` — Change Token Expired 후 re-import 대기
-4. `_firstImportCompletedAt` grace period — 첫 Import 완료 후 30초간 UC 생성 유예
+4. `_firstImportCompletedAt` grace period — 첫 Import 완료 후 120초간 UC 생성 유예
+5. `hasEverHadUserCollection` — 기존 유저 보호 (아래 참조)
 
-모든 Storage 호출은 `.notFound` 에러를 graceful하게 처리 (`try?` → nil, do-catch → debugPrint).
+모든 Storage 호출은 `.notFound` 에러를 graceful하게 처리 (`try?` → nil, do-catch → `os_log`).
 Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 정상 로드됨.
+
+### Known User Protection (`hasEverHadUserCollection`)
+
+**문제**: 앱 업데이트/iCloud 재로그인 시 `NSPersistentCloudKitContainer`가 CloudKit 미러를 재구성하면서 로컬 UC가 일시적으로 0개가 될 수 있음. 이때 빈 UC를 자동 생성하면 CloudKit에 빈 데이터가 Export되어 기존 클라우드 데이터가 오염됨.
+
+**해결**: `UserDefaults` 기반 `hasEverHadUserCollection` 플래그:
+- UC를 한 번이라도 성공적으로 fetch하면 `true`로 기록
+- 이후 UC가 0개여도 빈 UC를 생성하지 않고 `.notFound`를 throw
+- CloudKit re-import이 완료되면 정상 복구됨
+- `performCloudKitRecovery()`에서도 플래그 유지 (복구 = 기존 유저)
+
+**`shouldSuppressDataCreation` 통합 프로퍼티**: DailyTask 등 외부 Storage에서도 기본값 생성 억제 판단에 사용:
+- `isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress` 중 하나라도 true
+- grace period (120초) 내
+- `hasEverHadUserCollection == true`
 
 **기존 중복 정리**: `consolidateUserCollections()` — 앱 시작/Import 완료 시 자동 실행 (5초 지연, DispatchWorkItem으로 중복 방지):
 - UC가 2개 이상이면 관계(relationships)가 가장 많은 UC 보존
@@ -219,3 +235,24 @@ Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 
 - `AppSettingView` — 복구 버튼 + ActivityIndicator
 - `DashboardCoordinator.showRecoveryResultAlert()`
 - `Localizable.strings` (ko/en) — 복구 관련 문자열 6개
+
+## Sync Status Display
+
+설정 화면에서 사용자가 iCloud 동기화 상태를 확인할 수 있는 정보 표시:
+
+- **로컬 레코드 수**: UC 존재 여부 + 총 레코드 수 (Items, Tasks, Villagers, Houses)
+- **마지막 동기화 시각**: Import/Export 중 가장 최근 성공 시각 (상대 시간 표시)
+- **동기화 진행 중**: Import 또는 sync reset 진행 시 "동기화 중..." 표시
+- **데이터 대기 중**: UC 미존재 시 "iCloud 데이터 대기 중..." 표시
+
+**관련 파일**:
+- `CoreDataStorage.fetchSyncStatus()`, `SyncStatusInfo` — 상태 조회
+- `CoreDataStorage.lastSuccessfulImportDate/ExportDate` — 성공 시각 추적
+- `AppSettingReactor` — `.loadSyncStatus` Action, `.setSyncStatus` Mutation
+- `AppSettingView` — `syncStatusLabel` + `updateSyncStatusLabel()`
+- `Localizable.strings` (ko/en) — 동기화 상태 문자열 5개
+
+## Error Logging
+
+모든 Storage 클래스의 에러 로깅이 `debugPrint()` (Release 빌드에서 무시됨)에서 `os_log(.error)` (Release에서도 기록)로 강화됨.
+Console.app 또는 Xcode에서 `CoreDataStorage`, `ItemsStorage`, `DailyTaskStorage` 등으로 필터하여 프로덕션 에러 추적 가능.

--- a/docs/features/icloud-sync.md
+++ b/docs/features/icloud-sync.md
@@ -171,7 +171,7 @@ Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 
 
 **문제**: 앱 업데이트/iCloud 재로그인 시 `NSPersistentCloudKitContainer`가 CloudKit 미러를 재구성하면서 로컬 UC가 일시적으로 0개가 될 수 있음. 이때 빈 UC를 자동 생성하면 CloudKit에 빈 데이터가 Export되어 기존 클라우드 데이터가 오염됨.
 
-**해결**: `UserDefaults` 기반 `hasEverHadUserCollection` 플래그:
+**해결**: `UserDefaults` 기반 `hasEverHadUserCollection` 플래그 (메모리 캐싱, 변경 시에만 write-through):
 - UC를 한 번이라도 성공적으로 fetch하면 `true`로 기록
 - 이후 UC가 0개여도 빈 UC를 생성하지 않고 `.notFound`를 throw
 - CloudKit re-import이 완료되면 정상 복구됨
@@ -179,8 +179,8 @@ Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 
 
 **`shouldSuppressDataCreation` 통합 프로퍼티**: DailyTask 등 외부 Storage에서도 기본값 생성 억제 판단에 사용:
 - `isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress` 중 하나라도 true
-- grace period (120초) 내
-- `hasEverHadUserCollection == true`
+- `isWithinGracePeriod` — 첫 Import 완료 후 `gracePeriodSeconds` (120초) 내
+- 주의: `hasEverHadUserCollection`은 포함하지 않음 — `getUserCollection()`에서만 사용 (포함 시 DailyTask 자동 생성 영구 차단)
 
 **기존 중복 정리**: `consolidateUserCollections()` — 앱 시작/Import 완료 시 자동 실행 (5초 지연, DispatchWorkItem으로 중복 방지):
 - UC가 2개 이상이면 관계(relationships)가 가장 많은 UC 보존
@@ -246,10 +246,11 @@ Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 
 - **데이터 대기 중**: UC 미존재 시 "iCloud 데이터 대기 중..." 표시
 
 **관련 파일**:
-- `CoreDataStorage.fetchSyncStatus()`, `SyncStatusInfo` — 상태 조회
+- `CoreDataStorage.fetchSyncStatus()`, `SyncStatusInfo`, `entityCounts(in:)` — 상태 조회 (logSyncDiagnostics와 공용)
 - `CoreDataStorage.lastSuccessfulImportDate/ExportDate` — 성공 시각 추적
 - `AppSettingReactor` — `.loadSyncStatus` Action, `.setSyncStatus` Mutation
 - `AppSettingView` — `syncStatusLabel` + `updateSyncStatusLabel()`
+- `DateFormatters.syncRelativeDate` — 상대 시간 포맷터 캐싱
 - `Localizable.strings` (ko/en) — 동기화 상태 문자열 5개
 
 ## Error Logging


### PR DESCRIPTION
## 문제

기존 유저로부터 **앱 업데이트 후 데이터가 반복적으로 초기화**된다는 피드백 접수.

> 최근들어 초기화만 세번째인데 로컬데이터를 아이클라우드 데이터에 올라가는 과정에 잘못이 된건지.. 기존에 있던 데이터가 초기화되는 업데이트 하면서 또 초기화가 됐네요..

### 근본 원인

앱 업데이트 / iCloud 재로그인 시 `NSPersistentCloudKitContainer`가 CloudKit 미러를 재구성하면서 로컬 UC가 **일시적으로 0개**가 되는 구간이 발생. 이때 `getUserCollection()`이 **빈 UC를 자동 생성**하고, 이 빈 UC가 CloudKit에 Export되면서 **기존 클라우드 데이터가 오염**됨.

```mermaid
sequenceDiagram
    participant App
    participant CoreData as CoreData (Local)
    participant CloudKit as CloudKit (Server)

    Note over App: 앱 업데이트 후 실행
    App->>CoreData: getUserCollection()
    CoreData-->>App: UC 0개 (미러 재구성 중)

    rect rgb(255,230,230)
    Note over App: ❌ 기존 동작 (데이터 유실)
    App->>CoreData: 빈 UC 생성
    CoreData->>CloudKit: Export 빈 UC
    Note over CloudKit: 기존 데이터 오염
    end
```

## 해결

### 1. 기존 유저 플래그 도입 (`hasEverHadUserCollection`) — P0

```mermaid
flowchart TD
    A[getUserCollection 호출] --> B{UC 존재?}
    B -->|Yes| C[✅ 반환 + 플래그 true 기록]
    B -->|No| D{억제 조건 체크}
    D -->|import/syncReset/gracePeriod| E[🛡️ .notFound throw]
    D -->|hasEverHadUserCollection=true| F[🛡️ .notFound throw<br/>빈 UC 생성 차단]
    D -->|모두 false + 신규유저| G[새 UC 생성]

    style F fill:#ffe0e0
    style E fill:#ffe0e0
    style G fill:#e0ffe0
```

- `UserDefaults` 기반 `hasEverHadUserCollection` 플래그
- UC를 한 번이라도 fetch 성공하면 `true` 기록
- 이후 UC가 0개여도 **빈 UC 생성을 차단**하여 CloudKit 데이터 오염 방지
- "데이터 초기화" 시에는 `clearHasEverHadUserCollection()`으로 리셋하여 정상 동작 보장

### 2. DailyTask 기본값 자동 생성 보호 — P0

- 기존: `isImportInProgress`만 체크
- 변경: `shouldSuppressDataCreation` 통합 프로퍼티로 교체 (import/syncReset/gracePeriod 모두 체크)
- 기존 유저의 커스텀 태스크가 하드코딩된 9개 기본 태스크로 덮어씌워지는 문제 방지

### 3. Grace Period 연장 (30s → 120s) — P0

대용량 데이터의 CloudKit re-import 시간을 충분히 확보.

### 4. 동기화 상태 표시 — P1

유저 요청사항:
> 아이클라우드에 업로드가 되어 있는지, 다운로드 가능한 데이터가 언제 데이터인지 알 수 있다면 좋을 거 같은데

설정 화면에 iCloud 동기화 상태를 한 줄로 표시:
- 동기화 중: `동기화 중...`
- 정상: `3분 전 동기화 · 152개 저장됨`
- 데이터 대기: `iCloud 데이터 대기 중...`

### 5. 에러 로깅 강화 — P1

모든 Storage 클래스의 `debugPrint(error)` → `os_log(.error)` 교체.
Release 빌드에서도 Console.app으로 프로덕션 에러 추적 가능.

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `CoreDataStorage.swift` | `hasEverHadUserCollection`, `shouldSuppressDataCreation`, `SyncStatusInfo`, `fetchSyncStatus()`, grace period 120s, 동기화 시각 추적 |
| `CoreDataDailyTaskStorage.swift` | 기본 태스크 생성 조건 `shouldSuppressDataCreation` 적용 |
| `CoreDataUserInfoStorage.swift` | 데이터 초기화 시 `clearHasEverHadUserCollection()` 호출 |
| `AppSettingReactor.swift` | `loadSyncStatus` Action/Mutation 추가 |
| `AppSettingView.swift` | 동기화 상태 라벨 + Row 간격 조정 |
| `Localizable.strings` (ko/en) | 동기화 상태 문자열 5개 추가 |
| 7개 Storage + Items + TasksEditReactor | `debugPrint` → `os_log` 교체 |
| `icloud-sync.md` | Known User Protection, Sync Status, Error Logging 섹션 추가 |

## 시나리오 검증

| 시나리오 | 결과 |
|----------|------|
| A. 앱 업데이트 후 CloudKit 미러 재구성 | ✅ 빈 UC 생성 차단 |
| B. 완전히 새로운 유저 (첫 설치) | ✅ 정상 UC 생성 |
| C. 기존 유저, CloudKit re-import 완료 | ✅ 정상 복구 |
| D. 유저가 "데이터 초기화" 실행 | ✅ 플래그 리셋 → 새 UC 정상 생성 |
| E. 기존 유저의 DailyTask 자동 생성 | ✅ 정상 동작 (영구 차단 아님) |
| F. 앱 업데이트 중 DailyTask 보호 | ✅ 기본 태스크 덮어쓰기 방지 |

## Test Plan

- [x] 기존 데이터가 있는 기기에서 앱 업데이트 후 데이터 유지 확인
- [ ] 신규 설치 시 정상 UC 생성 및 DailyTask 기본값 생성 확인
- [ ] "데이터 초기화" 후 새 데이터 입력 가능 확인
- [ ] "iCloud에서 데이터 복구" 후 정상 복구 확인
- [ ] 설정 화면에서 동기화 상태 표시 확인 (동기화 시각, 저장 개수)
- [ ] iCloud 로그아웃/재로그인 시 데이터 유지 확인