### PR TITLE
✨ [feat] iCloud 동기화 추적용 원격 로그 인프라 구축

### DIFF
--- a/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/CoreDataStorage/CoreDataStorage.swift
@@ -108,7 +108,7 @@ final class CoreDataStorage {
     /// 의도적 데이터 초기화 시 호출 — 새 UC 생성을 다시 허용
     func clearHasEverHadUserCollection() {
         hasEverHadUserCollection = false
-        os_log(.info, log: .default, "🛡️ hasEverHadUserCollection cleared (intentional reset)")
+        Log.info("hasEverHadUserCollection cleared (intentional reset)")
     }
 
     // MARK: - Recovery Grace Period
@@ -122,7 +122,7 @@ final class CoreDataStorage {
     /// 복구 시작 시각 기록 — 재시작 후 grace window 계산에 사용
     func markRecoveryInitiated() {
         UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.recoveryInitiatedAtKey)
-        os_log(.info, log: .default, "🔄 Recovery initiated timestamp recorded")
+        Log.info("recovery initiated timestamp recorded (10min grace started)")
     }
 
     /// Recovery 완료 후 UC가 정상 복구되면 호출하여 플래그 정리
@@ -236,13 +236,14 @@ final class CoreDataStorage {
     /// 신규 설치 시 호출 — CloudKit Import 완료까지 로컬 UC 생성을 억제
     func markWaitingForFirstImport() {
         isWaitingForFirstImport = true
-        os_log(.info, log: .default, "🚀 Marked waiting for first CloudKit import")
+        Log.info("markWaitingForFirstImport (fresh install path)")
+        Log.setContext(Log.Key.isFreshInstall, true)
     }
 
     /// Import 대기 플래그 해제 — setupApp() 또는 no-iCloud 경로에서 호출
     func clearWaitingForFirstImport() {
         isWaitingForFirstImport = false
-        os_log(.info, log: .default, "🚀 Cleared waiting for first CloudKit import")
+        Log.info("clearWaitingForFirstImport")
     }
 
     // MARK: - Persistent History Cleanup
@@ -356,7 +357,8 @@ final class CoreDataStorage {
 
     @objc private func handleSyncWillReset(_ notification: Notification) {
         isSyncResetInProgress = true
-        os_log(.info, log: .default, "🔄 Sync reset detected (WillReset) — orphan cleanup suppressed")
+        Log.warning("sync reset WillReset — Change Token Expired, orphan cleanup suppressed")
+        Log.event(.tokenExpired)
     }
 
     @objc private func handleSyncDidReset(_ notification: Notification) {
@@ -492,6 +494,12 @@ final class CoreDataStorage {
             object: nil,
             userInfo: ["reason": reason]
         )
+
+        Log.warning("cloud sync failed reason=\(reason) code=\(nsError.code)")
+        Log.event(.cloudSyncFailed, parameters: [
+            Log.Param.reason: reason,
+            Log.Param.code: nsError.code
+        ])
     }
 
     // MARK: - Account Change Observation
@@ -539,49 +547,64 @@ extension CoreDataStorage {
         return counts
     }
 
-    /// CloudKit Import/Export 이벤트 후 데이터 상태를 로깅 (5초 throttle)
-    func logSyncDiagnostics(phase: String) {
-        let shouldProceed = lastDiagnosticsDate.withLock { lastDate -> Bool in
-            let now = Date()
-            guard now.timeIntervalSince(lastDate) >= 5 else {
-                return false
+    /// CloudKit 이벤트 후 데이터 상태를 os_log에 기록하고 Crashlytics 세션 스냅샷을 갱신한다.
+    /// 한 번의 background fetch로 두 용도를 모두 처리.
+    ///
+    /// - Parameters:
+    ///   - phase: 호출 지점을 식별하는 라벨 (예: "Import-end", "UC-missing")
+    ///   - throttled: true면 5초 내 재호출 시 skip. UC-missing처럼 즉시 컨텍스트가 필요한 경우 false.
+    func logSyncDiagnostics(phase: String, throttled: Bool = true) {
+        if throttled {
+            let shouldProceed = lastDiagnosticsDate.withLock { lastDate -> Bool in
+                let now = Date()
+                guard now.timeIntervalSince(lastDate) >= 5 else { return false }
+                lastDate = now
+                return true
             }
-
-            lastDate = now
-            return true
+            guard shouldProceed else {
+                os_log(.info, log: .default, "📊 [%{public}@] skipped (throttled)", phase)
+                return
+            }
         }
 
-        guard shouldProceed else {
-            os_log(.info, log: .default, "📊 [%{public}@] skipped (throttled)", phase)
-            return
-        }
-
-        persistentContainer.performBackgroundTask { context in
+        persistentContainer.performBackgroundTask { [weak self] context in
+            guard let self else { return }
             context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
 
             let counts = self.entityCounts(in: context)
+            let ucCount = counts["UserCollectionEntity"] ?? -1
+            let itemCount = counts["ItemEntity"] ?? -1
 
             os_log(.info, log: .default,
                    "📊 [%{public}@] UC=%d Items=%d Tasks=%d VLike=%d VHouse=%d NPC=%d Variants=%d",
                    phase,
-                   counts["UserCollectionEntity"] ?? -1,
-                   counts["ItemEntity"] ?? -1,
+                   ucCount, itemCount,
                    counts["DailyTaskEntity"] ?? -1,
                    counts["VillagersLikeEntity"] ?? -1,
                    counts["VillagersHouseEntity"] ?? -1,
                    counts["NPCLikeEntity"] ?? -1,
                    counts["VariantCollectionEntity"] ?? -1)
 
+            Log.snapshot(Log.Snapshot(
+                ucCount: ucCount,
+                itemCount: itemCount,
+                taskCount: counts["DailyTaskEntity"] ?? -1,
+                villagerCount: (counts["VillagersLikeEntity"] ?? 0) + (counts["VillagersHouseEntity"] ?? 0),
+                hasEverHadUC: self.hasEverHadUserCollection,
+                isFreshInstall: nil,
+                isWaitingForFirstImport: self.isWaitingForFirstImport,
+                isImportInProgress: self.isImportInProgress,
+                isSyncResetInProgress: self.isSyncResetInProgress,
+                isWithinRecoveryGracePeriod: self.isWithinRecoveryGracePeriod,
+                lastImportDate: self.lastSuccessfulImportDate,
+                lastExportDate: self.lastSuccessfulExportDate
+            ))
+
             // UC가 2개 이상일 때만 상세 진단 (중복 탐지)
-            let ucCount = counts["UserCollectionEntity"] ?? 0
-            guard ucCount > 1 else {
-                return
-            }
+            guard ucCount > 1 else { return }
 
             let ucRequest = UserCollectionEntity.fetchRequest()
-            guard let ucResults = try? context.fetch(ucRequest) else {
-                return
-            }
+            guard let ucResults = try? context.fetch(ucRequest) else { return }
 
             for (index, uc) in ucResults.enumerated() {
                 let critters = uc.critters?.count ?? 0
@@ -679,6 +702,12 @@ extension CoreDataStorage {
                    "🔧 Consolidation: %d UCs found, keeping UC with %d relationships",
                    allUCs.count, self.relationshipCount(of: keptUC))
 
+            Log.info("consolidating \(allUCs.count) UCs, kept relationships=\(self.relationshipCount(of: keptUC))")
+            Log.event(.ucConsolidated, parameters: [
+                Log.Param.ucTotal: allUCs.count,
+                Log.Param.keptRelationships: self.relationshipCount(of: keptUC)
+            ])
+
             for orphanUC in sorted.dropFirst() {
                 os_log(.info, log: .default,
                        "🔧 Consolidation: reassigning & deleting UC id=%{public}@ (%d relationships)",
@@ -767,10 +796,18 @@ extension CoreDataStorage {
 
             // 안전 확인 통과 후에만 실제 객체를 fetch하여 삭제
             if let orphans = try? context.fetch(orphanCountRequest) {
-                // 프로덕션에서도 추적 가능하도록 .error 레벨로 기록 (데이터 삭제는 항상 감사 대상)
-                os_log(.error, log: .default,
-                       "🔧 Orphan cleanup: %{public}@ → %d orphans / %d total WILL BE DELETED",
-                       entity, orphans.count, totalCount)
+                // 데이터 삭제는 항상 감사 대상 — Crashlytics 비치명 에러로 승격
+                let userInfo: [String: Any] = [
+                    Log.Param.entity: entity,
+                    Log.Param.deleted: orphans.count,
+                    Log.Param.total: totalCount
+                ]
+                Log.event(.orphanCleanup, parameters: userInfo)
+                Log.error(
+                    name: "OrphanCleanupDelete",
+                    reason: "\(entity) \(orphans.count)/\(totalCount) deleted",
+                    userInfo: userInfo
+                )
                 orphans.forEach { context.delete($0) }
                 totalOrphans += orphans.count
             }
@@ -871,14 +908,21 @@ extension CoreDataStorage {
         // 4. 첫 Import 완료 후 120초 유예 (relationship 해소 시간 확보)
         // 5. 기존 유저 — 이전에 UC가 존재했으므로, CloudKit re-import 대기 필요
         if isWaitingForFirstImport || isImportInProgress || isSyncResetInProgress {
-            os_log(.info, log: .default,
-                   "⏳ getUserCollection: No UC found — skipping creation (waiting=%{public}@, importing=%{public}@, reset=%{public}@)",
-                   isWaitingForFirstImport.description, isImportInProgress.description, isSyncResetInProgress.description)
+            Log.info("getUserCollection: No UC — skipping (waiting=\(isWaitingForFirstImport), importing=\(isImportInProgress), reset=\(isSyncResetInProgress))")
+            Log.event(.ucCreationSuppressed, parameters: [
+                Log.Param.reason: SuppressionReason.syncInProgress.rawValue,
+                Log.Param.waiting: isWaitingForFirstImport.description,
+                Log.Param.importing: isImportInProgress.description,
+                Log.Param.reset: isSyncResetInProgress.description
+            ])
             throw CoreDataStorageError.notFound
         }
 
         if isWithinGracePeriod {
-            os_log(.info, log: .default, "⏳ getUserCollection: No UC found, within grace period (%.0fs) — skipping creation", Self.gracePeriodSeconds)
+            Log.info("getUserCollection: No UC, within \(Int(Self.gracePeriodSeconds))s grace period — skipping")
+            Log.event(.ucCreationSuppressed, parameters: [
+                Log.Param.reason: SuppressionReason.gracePeriod.rawValue
+            ])
             throw CoreDataStorageError.notFound
         }
 
@@ -890,16 +934,31 @@ extension CoreDataStorage {
         //       복구 자체가 "로컬 재생성 + CloudKit에서 재import" 플로우이므로 안전.
         if hasEverHadUserCollection {
             if isWithinRecoveryGracePeriod {
-                os_log(.info, log: .default,
-                       "🔄 getUserCollection: No UC found, within recovery grace period — allowing UC creation")
+                Log.info("UC created within recovery grace period (hasEverHadUC=true)")
+                Log.event(.ucCreated, parameters: [Log.Param.path: UCCreationPath.recoveryGrace.rawValue])
+                logSyncDiagnostics(phase: "UC-created-recovery", throttled: false)
                 return UserCollectionEntity(UserInfo(), context: context)
             }
-            os_log(.error, log: .default,
-                   "🛡️ getUserCollection: No UC found but hasEverHadUserCollection=true — blocking empty UC creation to protect cloud data")
+            // 핵심 데이터 유실 증상: "기존 유저인데 UC가 사라짐".
+            // 3.2.0 이후 클레임의 주 증상으로 추정되는 상태.
+            Log.warning("UC missing but hasEverHadUC=true — user data appears reset, blocking empty UC to protect cloud")
+            Log.event(.ucMissing)
+            logSyncDiagnostics(phase: "UC-missing", throttled: false)
+            Log.error(
+                name: "UserCollectionMissing",
+                reason: "hasEverHadUserCollection=true but UC count=0",
+                userInfo: [
+                    Log.Param.waiting: isWaitingForFirstImport,
+                    Log.Param.importing: isImportInProgress,
+                    Log.Param.reset: isSyncResetInProgress,
+                    Log.Param.recoveryGrace: isWithinRecoveryGracePeriod
+                ]
+            )
             throw CoreDataStorageError.notFound
         }
 
-        os_log(.info, log: .default, "⚠️ getUserCollection: No UC found (fresh user) — creating new one")
+        Log.info("UC created for fresh user")
+        Log.event(.ucCreated, parameters: [Log.Param.path: UCCreationPath.freshUser.rawValue])
         return UserCollectionEntity(UserInfo(), context: context)
     }
 
@@ -986,7 +1045,8 @@ extension CoreDataStorage {
                 // 10분간은 UC 생성을 허용하여 앱이 동작 가능하도록 보장
                 self.markRecoveryInitiated()
 
-                os_log(.info, log: .default, "🔄 Recovery: store files deleted — app restart required for CloudKit re-import")
+                Log.warning("recovery: local store wiped, awaiting restart + CloudKit re-import")
+                Log.event(.recoveryTriggered)
                 completion(.success(()))
             } catch {
                 os_log(.error, log: .default, "🔄 Recovery failed: %{public}@", error.localizedDescription)
@@ -994,6 +1054,16 @@ extension CoreDataStorage {
             }
         }
     }
+}
+
+private enum UCCreationPath: String {
+    case freshUser = "fresh_user"
+    case recoveryGrace = "recovery_grace"
+}
+
+private enum SuppressionReason: String {
+    case syncInProgress = "sync_in_progress"
+    case gracePeriod = "grace_period"
 }
 
 extension NSManagedObjectContext {

--- a/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Log.swift
+++ b/Animal-Crossing-Wiki/Projects/App/Sources/Utility/Log.swift
@@ -1,0 +1,204 @@
+//
+//  Log.swift
+//  ACNH-wiki
+//
+//  Created by Ari on 4/22/26.
+//
+
+import Foundation
+import OSLog
+import FirebaseCrashlytics
+import FirebaseAnalytics
+
+enum Log {
+
+    // MARK: - Event Names (Analytics)
+
+    enum Event: String {
+        case recoveryTriggered = "sync_recovery_triggered"
+        case orphanCleanup = "sync_orphan_cleanup"
+        case ucConsolidated = "sync_uc_consolidated"
+        case ucCreated = "sync_uc_created"
+        case tokenExpired = "sync_token_expired"
+        case ucMissing = "sync_user_collection_missing"
+        case ucCreationSuppressed = "sync_uc_creation_suppressed"
+        case cloudSyncFailed = "sync_cloud_failed"
+    }
+
+    /// Analytics event parameter keys. 동일 키가 여러 이벤트에서 재사용되므로 중앙화.
+    enum Param {
+        static let reason = "reason"
+        static let path = "path"
+        static let code = "code"
+        static let entity = "entity"
+        static let deleted = "deleted"
+        static let total = "total"
+        static let ucTotal = "uc_total"
+        static let keptRelationships = "kept_relationships"
+        static let message = "message"
+        static let errorName = "name"
+
+        // Sync flag keys (shared with Key below)
+        static let waiting = "waiting"
+        static let importing = "importing"
+        static let reset = "reset"
+        static let recoveryGrace = "recovery_grace"
+    }
+
+    // MARK: - Custom Key Names (Crashlytics)
+
+    enum Key {
+        static let ucCount = "sync_uc_count"
+        static let itemCount = "sync_item_count"
+        static let taskCount = "sync_task_count"
+        static let villagerCount = "sync_villager_count"
+        static let hasEverHadUC = "sync_has_ever_had_uc"
+        static let isFreshInstall = "sync_is_fresh_install"
+        static let isWaitingForFirstImport = "sync_waiting_first_import"
+        static let isImportInProgress = "sync_import_in_progress"
+        static let isSyncResetInProgress = "sync_reset_in_progress"
+        static let isWithinRecoveryGracePeriod = "sync_within_recovery_grace"
+        static let lastImportDate = "sync_last_import_at"
+        static let lastExportDate = "sync_last_export_at"
+        static let appVersion = "sync_app_version"
+    }
+
+    // MARK: - Internal
+
+    private static let crashlytics = Crashlytics.crashlytics()
+    private static let analyticsStringLimit = 100
+
+    private static func truncate(_ message: String) -> String {
+        guard message.count > analyticsStringLimit else {
+            return message
+        }
+        return String(message.prefix(analyticsStringLimit))
+    }
+
+    // MARK: - Level-based Logging
+    //
+    // 모든 레벨은 세 갈래로 전송된다:
+    //   1) os_log            — Console.app / Xcode에서 로컬 확인
+    //   2) Crashlytics.log   — 세션 breadcrumb (크래시/비치명 에러 발생 시 함께 업로드)
+    //   3) Analytics.logEvent — Firebase Analytics 콘솔에 집계 (에러 없이도 가시성 확보)
+    //
+    // Analytics 파라미터 값은 100자로 자동 truncate된다.
+    // verbose/debug는 Analytics 쿼터 보호를 위해 DEBUG 빌드에서만 Analytics로 전송된다.
+
+    private static func emit(level: String, symbol: String, osLogType: OSLogType, message: String, sendToAnalytics: Bool) {
+        crashlytics.log("[\(level.uppercased())] \(message)")
+        os_log(osLogType, log: .default, "%{public}@ %{public}@", symbol, message)
+        guard sendToAnalytics else {
+            return
+        }
+        Analytics.logEvent("log_\(level)", parameters: [Param.message: truncate(message)])
+    }
+
+    static func verbose(_ message: String) {
+        #if DEBUG
+        emit(level: "verbose", symbol: "🔍", osLogType: .debug, message: message, sendToAnalytics: true)
+        #else
+        emit(level: "verbose", symbol: "🔍", osLogType: .debug, message: message, sendToAnalytics: false)
+        #endif
+    }
+
+    static func debug(_ message: String) {
+        #if DEBUG
+        emit(level: "debug", symbol: "🐛", osLogType: .debug, message: message, sendToAnalytics: true)
+        #else
+        emit(level: "debug", symbol: "🐛", osLogType: .debug, message: message, sendToAnalytics: false)
+        #endif
+    }
+
+    static func info(_ message: String) {
+        emit(level: "info", symbol: "ℹ️", osLogType: .info, message: message, sendToAnalytics: true)
+    }
+
+    static func warning(_ message: String) {
+        emit(level: "warning", symbol: "⚠️", osLogType: .error, message: message, sendToAnalytics: true)
+    }
+
+    // MARK: - Non-fatal Error
+
+    /// Crashlytics 비치명 에러 업로드. 세션의 breadcrumb + custom keys가 함께 전송된다.
+    /// 사용자 클레임 추적의 핵심 진입점.
+    static func error(
+        name: String,
+        reason: String,
+        userInfo: [String: Any] = [:]
+    ) {
+        var info = userInfo
+        info[NSLocalizedDescriptionKey] = reason
+        let nsError = NSError(domain: "Log.\(name)", code: 0, userInfo: info)
+        crashlytics.record(error: nsError)
+        os_log(.error, log: .default, "❗️ non-fatal: %{public}@ — %{public}@", name, reason)
+        Analytics.logEvent("log_error", parameters: [
+            Param.errorName: truncate(name),
+            Param.reason: truncate(reason)
+        ])
+    }
+
+    // MARK: - Analytics
+
+    static func event(_ event: Event, parameters: [String: Any] = [:]) {
+        Analytics.logEvent(event.rawValue, parameters: parameters)
+        crashlytics.log("[EVENT] \(event.rawValue) \(parameters)")
+        os_log(.info, log: .default, "📈 %{public}@", event.rawValue)
+    }
+
+    /// 사용자 탭/클릭 추적. Firebase Analytics의 `select_content` 스키마로 기록.
+    static func click(_ name: String, parameters: [String: Any] = [:]) {
+        var params = parameters
+        params[AnalyticsParameterItemID] = name
+        params[AnalyticsParameterContentType] = "click"
+        Analytics.logEvent(AnalyticsEventSelectContent, parameters: params)
+        os_log(.info, log: .default, "👆 click=%{public}@", name)
+    }
+
+    // MARK: - Context (Crashlytics custom keys)
+
+    static func setContext(_ key: String, _ value: Any?) {
+        guard let value else {
+            crashlytics.setCustomValue("", forKey: key)
+            return
+        }
+        crashlytics.setCustomValue(value, forKey: key)
+    }
+
+    /// 엔티티 카운트와 sync 플래그를 한 번에 custom keys로 전송.
+    struct Snapshot {
+        var ucCount: Int
+        var itemCount: Int
+        var taskCount: Int
+        var villagerCount: Int
+        var hasEverHadUC: Bool
+        var isFreshInstall: Bool?
+        var isWaitingForFirstImport: Bool
+        var isImportInProgress: Bool
+        var isSyncResetInProgress: Bool
+        var isWithinRecoveryGracePeriod: Bool
+        var lastImportDate: Date?
+        var lastExportDate: Date?
+    }
+
+    static func snapshot(_ snapshot: Snapshot) {
+        setContext(Key.ucCount, snapshot.ucCount)
+        setContext(Key.itemCount, snapshot.itemCount)
+        setContext(Key.taskCount, snapshot.taskCount)
+        setContext(Key.villagerCount, snapshot.villagerCount)
+        setContext(Key.hasEverHadUC, snapshot.hasEverHadUC)
+        if let isFreshInstall = snapshot.isFreshInstall {
+            setContext(Key.isFreshInstall, isFreshInstall)
+        }
+        setContext(Key.isWaitingForFirstImport, snapshot.isWaitingForFirstImport)
+        setContext(Key.isImportInProgress, snapshot.isImportInProgress)
+        setContext(Key.isSyncResetInProgress, snapshot.isSyncResetInProgress)
+        setContext(Key.isWithinRecoveryGracePeriod, snapshot.isWithinRecoveryGracePeriod)
+        setContext(Key.lastImportDate, snapshot.lastImportDate?.timeIntervalSince1970 ?? 0)
+        setContext(Key.lastExportDate, snapshot.lastExportDate?.timeIntervalSince1970 ?? 0)
+
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            setContext(Key.appVersion, version)
+        }
+    }
+}

--- a/docs/features/icloud-sync.md
+++ b/docs/features/icloud-sync.md
@@ -286,3 +286,69 @@ Import 완료 후 Path-B(`setUpUserCollection`)가 재실행되어 데이터가 
 
 모든 Storage 클래스의 에러 로깅이 `debugPrint()` (Release 빌드에서 무시됨)에서 `os_log(.error)` (Release에서도 기록)로 강화됨.
 Console.app 또는 Xcode에서 `CoreDataStorage`, `ItemsStorage`, `DailyTaskStorage` 등으로 필터하여 프로덕션 에러 추적 가능.
+
+## Remote Telemetry (Firebase)
+
+3.2.0 이후 "로컬 데이터가 초기화되었다"는 클레임을 원격에서 추적하기 위해, `Utility/Log.swift`에서
+Crashlytics(세션 breadcrumb + custom keys + 비치명 에러)와 Analytics(집계 이벤트/클릭)를 통합 래핑.
+
+### Logging API
+
+모든 레벨(`verbose` ~ `error`)은 **3-way fan-out**: `os_log` + Crashlytics breadcrumb + Analytics 이벤트.
+에러/크래시 없이도 Analytics 콘솔에서 로그가 보이며, 문제 발생 시엔 Crashlytics breadcrumb으로 세션 맥락이 함께 업로드됨.
+
+| 호출 | 용도 | Analytics 이벤트명 |
+|------|------|-------------------|
+| `Log.verbose(_:)` | 상세 추적 | `log_verbose` |
+| `Log.debug(_:)` | 디버그 흐름 | `log_debug` |
+| `Log.info(_:)` | 일반 흐름, 결정 지점 | `log_info` |
+| `Log.warning(_:)` | 주의 상태 | `log_warning` |
+| `Log.error(name:reason:userInfo:)` | **비치명 에러 업로드** | `log_error` + Crashlytics `recordError` |
+| `Log.event(_:parameters:)` | 구조화된 집계 이벤트 | (Event enum) |
+| `Log.click(_:parameters:)` | 사용자 탭 추적 | `select_content` |
+| `Log.setContext(_:_:)` | 커스텀 키 단건 설정 | — (Crashlytics 전용) |
+| `Log.snapshot(...)` | 엔티티 카운트/플래그 일괄 전송 | — (Crashlytics 전용) |
+
+**메시지 길이**: Analytics 파라미터 제한(100자)에 맞춰 자동 잘림.
+
+### Analytics Events (집계)
+
+| Event | 발생 지점 |
+|-------|-----------|
+| `sync_recovery_triggered` | `performCloudKitRecovery` 성공 — 사용자가 설정에서 복원 실행 |
+| `sync_orphan_cleanup` | `cleanupOrphanedEntities`가 실제로 레코드 삭제 (entity/count 파라미터) |
+| `sync_uc_consolidated` | 중복 UC가 통합됨 (uc_total/kept_relationships) |
+| `sync_uc_created` | 새 UC 생성 (path: fresh_user \| recovery_grace) |
+| `sync_uc_creation_suppressed` | UC 생성이 억제됨 (reason: sync_in_progress \| grace_period) |
+| `sync_token_expired` | `NSCloudKitMirroringDelegateWillReset` 감지 |
+| `sync_user_collection_missing` | **핵심 증상**: hasEverHadUC=true인데 UC=0 |
+| `sync_cloud_failed` | CloudKit Export/Import 실패 (reason/code) |
+
+### Crashlytics Custom Keys (세션 스냅샷)
+
+`logSyncDiagnostics(phase:throttled:)` 호출 시 os_log 진단 + `Log.snapshot` 갱신을 한 번의 background fetch로 수행.
+Import 종료, UC 생성(recovery grace), UC missing 시점에 자동 전송. UC missing처럼 즉시 컨텍스트가 필요한
+경우 `throttled: false` 로 호출하여 5초 throttle을 우회.
+
+- `sync_uc_count` / `sync_item_count` / `sync_task_count` / `sync_villager_count`
+- `sync_has_ever_had_uc` / `sync_is_fresh_install`
+- `sync_waiting_first_import` / `sync_import_in_progress` / `sync_reset_in_progress`
+- `sync_within_recovery_grace`
+- `sync_last_import_at` / `sync_last_export_at` (epoch seconds)
+- `sync_app_version`
+
+### 비치명 에러 (Crashlytics `recordError`)
+
+세션 breadcrumb과 custom keys를 포함한 상세 컨텍스트를 Firebase Crashlytics에 업로드:
+
+- `Log.UserCollectionMissing` — hasEverHadUC=true + UC=0 관측
+- `Log.OrphanCleanupDelete` — 실제 orphan 삭제 발생 (감사 로그)
+
+### 조사 가이드
+
+사용자 클레임 접수 시:
+
+1. Firebase Crashlytics → Non-fatal issues → `UserCollectionMissing` 필터
+2. 해당 세션의 breadcrumb(`log()` 문자열)으로 이벤트 순서 재구성
+3. custom keys로 그 순간의 엔티티 수/플래그 상태 확인
+4. Analytics → `sync_user_collection_missing` 분포로 버전/일자별 발생 빈도 확인


### PR DESCRIPTION
## 🚨 문제

3.2.0 이후 사용자로부터 **"iCloud 백업 관련해서 로컬 데이터가 모두 초기화됐다"** 는 클레임이 지속적으로 접수되고 있음.

- 📉 재현 시나리오가 불명확 — 특정 조건에서만 발생
- 🔇 기존 로깅은 모두 로컬(`os_log`) → 사용자 기기의 Console.app에만 남음
- 🙅 원격에서 언제/어떤 플래그 상태에서 데이터가 사라졌는지 **추적 불가능**
- 📞 유일한 조사 수단은 1:1 문의로 받은 사용자 증언 뿐

## 🔍 원인 분석

CoreData + CloudKit 동기화 경로 중 **데이터 삭제/UC 재생성이 일어날 수 있는 6개 결정 지점** 을 식별:

| # | 지점 | 위험 |
|---|------|------|
| 1 | `performCloudKitRecovery` | 사용자가 명시적 복원 → 로컬 store 전체 wipe |
| 2 | `cleanupOrphanedEntities` | UC 관계 없는 엔티티 자동 삭제 (감사 필요) |
| 3 | `consolidateUserCollections` | 중복 UC 통합 시 데이터 소실 가능성 |
| 4 | `handleSyncWillReset` | Change Token Expired → CloudKit 미러 재구성 |
| 5 | `getUserCollection` UC 생성 경로 | 억제 플래그에 따라 빈 UC 생성 가능 |
| 6 | **`hasEverHadUC=true` 인데 UC=0 관측** | **← 클레임의 핵심 증상으로 추정** |

> **6번** 이 결정적 — 기존 유저임에도 UC가 사라진 상태를 감지하면 "데이터가 초기화됐다"는 증상 그 자체.

## 💡 접근 방식: 왜 Firebase 기반인가?

후보 검토:

| 옵션 | 평가 |
|------|------|
| `swift-log` (apple/swift-log) | ❌ 로깅 API 추상화일 뿐 — 원격 전송하려면 추가 핸들러 + 백엔드 필요. 신규 의존성 추가도 팀 승인 필요 (CLAUDE.md Critical Rule #1) |
| 자체 서버 + REST 업로드 | ❌ 인프라 추가 비용 |
| **Firebase Crashlytics + Analytics** | ✅ **이미 통합됨** (`Tuist/Package.swift`, `AppDelegate.swift`) — 추가 의존성 0 |

**결정**: 기존 Firebase SDK를 래핑한 단일 진입점 `Log` 를 도입하여 3-way fan-out.

## 🛠 구현

### 1. `Utility/Log.swift` — 통합 로깅 진입점

```mermaid
flowchart LR
    Call["Log.info / warning / event / error / click"]
    OSLog["os_log<br/>📱 Console.app<br/>🖥 Xcode 디버거"]
    Breadcrumb["Crashlytics.log<br/>🔐 세션 breadcrumb<br/>에러 시 함께 업로드"]
    Analytics["Analytics.logEvent<br/>📊 Firebase Analytics<br/>실시간 집계"]
    Error["Crashlytics.record<br/>❗ 비치명 에러 업로드"]

    Call --> OSLog
    Call --> Breadcrumb
    Call --> Analytics
    Call -.Log.error만.-> Error

    style Call fill:#4A90E2,color:#fff
    style Error fill:#E74C3C,color:#fff
```

- **레벨**: `verbose` / `debug` / `info` / `warning` / `error`
- **집계 이벤트**: `event(_:parameters:)` — 구조화된 Event enum (8종)
- **클릭 추적**: `click(_:parameters:)` — Firebase `select_content` 스키마
- **스냅샷**: `snapshot(_:)` — 엔티티 카운트/플래그 일괄 전송 (Crashlytics custom keys)
- 🚫 `verbose` / `debug` 는 Analytics 쿼터 보호를 위해 DEBUG 빌드에서만 Analytics 전송
- ✂️ 파라미터 100자 자동 truncate (Firebase SDK 제한)

### 2. `CoreDataStorage.swift` — 6개 결정 지점 Instrument

```mermaid
flowchart TD
    Start([CloudKit 이벤트 / DAO 호출]) --> GetUC{getUserCollection}

    GetUC -->|UC 존재| OK[정상 반환]
    GetUC -->|UC=0 &<br/>sync in progress| Suppress["sync_uc_creation_suppressed<br/>📈 event"]
    GetUC -->|UC=0 &<br/>fresh user| Create["sync_uc_created<br/>📈 event"]
    GetUC -->|**UC=0 &<br/>hasEverHadUC=true**| Missing["🚨 UserCollectionMissing<br/>❗ Log.error 비치명<br/>📸 snapshot 강제 fetch"]

    Reset([Change Token Expired]) --> TokenExpired["sync_token_expired<br/>⚠️ Log.warning"]
    Orphan([cleanupOrphanedEntities]) --> OrphanEvent["sync_orphan_cleanup<br/>❗ Log.error 감사 로그"]
    Consolidate([중복 UC 통합]) --> ConEvent["sync_uc_consolidated<br/>📈 event"]
    Recovery([사용자 복원 실행]) --> RecEvent["sync_recovery_triggered<br/>⚠️ Log.warning"]
    Fail([CloudKit Export/Import 실패]) --> FailEvent["sync_cloud_failed<br/>⚠️ Log.warning"]

    style Missing fill:#E74C3C,color:#fff
    style OrphanEvent fill:#F39C12,color:#fff
    style RecEvent fill:#F39C12,color:#fff
```

### 3. 부가 개선 (리뷰 라운드에서 반영)

- **중복 fetch 제거**: `logSyncDiagnostics` + `captureTelemetrySnapshot` 통합 → Import-end에서 14 count queries → 7로 감소
- **throttle 우회 옵션**: UC-missing 같은 긴급 경로는 `throttled: false` 로 5초 쓰로틀 무시
- **stringly-typed 파라미터 제거**: `SuppressionReason` / `UCCreationPath` fileprivate enum, `Log.Param` 중앙화
- **`Log.Snapshot` struct**: 12-parameter 시그니처 → 명명 필드 구조체

## 🔧 해결: UserCollectionMissing 감지 흐름

클레임의 핵심 증상이 발생하는 순간을 어떻게 포착하는가:

```mermaid
sequenceDiagram
    participant User as 사용자 기기
    participant CD as CoreDataStorage
    participant Log as Log
    participant FB as Firebase

    User->>CD: DAO 호출 (예: 아이템 조회)
    CD->>CD: getUserCollection()
    Note over CD: UC=0 && hasEverHadUC=true<br/>(기존 유저인데 UC 사라짐!)
    CD->>Log: Log.warning("UC missing...")
    Log->>FB: Crashlytics breadcrumb [WARN]
    Log->>FB: Analytics log_warning
    CD->>Log: Log.event(.ucMissing)
    Log->>FB: Analytics sync_user_collection_missing
    CD->>Log: logSyncDiagnostics(throttled: false)
    Log->>FB: Crashlytics custom keys<br/>(UC 수/Item 수/플래그)
    CD->>Log: Log.error(name: UserCollectionMissing)
    Log->>FB: ❗️ Non-fatal error<br/>+ 세션 breadcrumb<br/>+ custom keys 함께 업로드
```

**결과**: Firebase 콘솔에서 사용자 클레임의 **정확한 상태 스냅샷과 이벤트 순서**를 재구성 가능.

## 🧪 검증

- [x] `mise x -- tuist generate && xcodebuild build` → **BUILD SUCCEEDED**
- [x] SwiftLint 경고 없음 (Log.swift 신규 위반 0건)
- [x] iPhone 16 Pro Simulator 실행 + `log stream` 캡처로 다음 출력 실시간 확인:

```
ℹ️ clearWaitingForFirstImport                    ← Log.info
📊 [Pre-setup] UC=1 Items=0 Tasks=9 ...           ← logSyncDiagnostics
⚠️ cloud sync failed reason=unknown code=134400   ← Log.warning
📈 sync_cloud_failed                              ← Log.event
```

- [x] Firebase SDK 초기화 확인: `Analytics v.12.7.0 started / collection enabled`
- [x] `GDTCCTUploader-upload` 백그라운드 태스크 실행 확인 → Analytics → Firebase 서버 업로드 경로 동작
- [ ] QA: 실기기에서 Firebase 콘솔 DebugView로 이벤트 수신 확인
- [ ] 배포 후 모니터링: 3.2.0~3.2.2 유저 클레임이 `UserCollectionMissing` non-fatal로 수집되는지

## 📈 조사 워크플로우 (PR 머지 후)

사용자 클레임 접수 시:

```mermaid
flowchart TD
    Claim([사용자 문의 접수]) --> Step1
    Step1[1\. Firebase Crashlytics<br/>→ Non-fatal issues<br/>→ Log.UserCollectionMissing 필터]
    Step1 --> Step2[2\. 해당 세션의 breadcrumb 확인<br/>- INFO/WARN 라인으로 이벤트 순서 재구성]
    Step2 --> Step3[3\. Custom keys 확인<br/>- sync_uc_count / sync_has_ever_had_uc<br/>- sync_waiting_first_import / sync_reset_in_progress<br/>- sync_last_import_at / sync_app_version]
    Step3 --> Step4[4\. Firebase Analytics<br/>→ sync_user_collection_missing 분포<br/>- 버전별 / 일자별 재현율 확인]
    Step4 --> Fix([원인 특정 → 수정 PR])
```

## 🔮 Follow-up (이번 PR 밖)

- `postSyncFailureIfNeeded` 가 `NSCocoaErrorDomain` 에러도 매핑 (현재 `reason: "unknown"`으로 처리됨 — 시뮬레이션에서 `code=134400` 관측)
- 설정 화면에 UID/디바이스 식별자 표시 → 사용자 문의 시 Firebase 세션 매칭 용이
- 다른 Storage 클래스들도 점진적으로 `os_log` → `Log.*` 마이그레이션

## 📁 변경 파일

| 파일 | 설명 |
|------|------|
| `Utility/Log.swift` (신규) | 통합 로깅 진입점 |
| `CoreDataStorage/CoreDataStorage.swift` | 6개 결정 지점 instrument + 중복 fetch 정리 |
| `docs/features/icloud-sync.md` | Remote Telemetry 섹션 추가 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)